### PR TITLE
[codex] Fix Gradle build and contact flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.idea/

--- a/portfolio/.gitignore
+++ b/portfolio/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### OS files ###
+.DS_Store

--- a/portfolio/build.gradle
+++ b/portfolio/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.0'
+	id 'org.springframework.boot' version '4.0.3'
 	id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -25,10 +25,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/portfolio/gradle/wrapper/gradle-wrapper.properties
+++ b/portfolio/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/portfolio/src/main/java/com/codernawaki/portfolio/ContactController.java
+++ b/portfolio/src/main/java/com/codernawaki/portfolio/ContactController.java
@@ -1,21 +1,38 @@
 
 
+package com.codernawaki.portfolio;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
 @RestController
-class ContactController{
+class ContactController {
+
+    private static final String EMAIL_PATTERN = "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$";
 
     @PostMapping("/submitContactForm")
-    public String submitContactForm(@RequestBody ContactForm contactForm){
+    public ResponseEntity<Map<String, String>> submitContactForm(@RequestBody ContactForm contactForm) {
 
-        if(isValid(contactForm)){
-            return "Form submitted successfully";
-        }else{
-            return "Invalid form data.Please check your input.";
+        if (isValid(contactForm)) {
+            return ResponseEntity.ok(Map.of("message", "Form submitted successfully."));
         }
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message", "Invalid form data. Please check your input."));
     }
 
-    private boolean isValid(ContactForm contactForm){
-        return contactForm.getName()!=null && !contactForm.getName().trim().isEmpty()
-                && contactForm.getEmail()!=null && !contactForm.getEmail().matches("[^\\s@]+@[^\\s@]+\\.[^\\s@]+")
-                && contactForm.getMessage()!=null && !contactForm.getMessage().trim().isEmpty();
+    private boolean isValid(ContactForm contactForm) {
+        return contactForm != null
+                && contactForm.getName() != null
+                && !contactForm.getName().trim().isEmpty()
+                && contactForm.getEmail() != null
+                && contactForm.getEmail().matches(EMAIL_PATTERN)
+                && contactForm.getMessage() != null
+                && !contactForm.getMessage().trim().isEmpty();
     }
 }

--- a/portfolio/src/main/java/com/codernawaki/portfolio/ContactForm.java
+++ b/portfolio/src/main/java/com/codernawaki/portfolio/ContactForm.java
@@ -1,10 +1,36 @@
 
 
-class ContactForm{
+package com.codernawaki.portfolio;
+
+public class ContactForm {
 
     private String name;
     private String email;
     private String message;
 
-    //getters and setters
+    // Getters
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    // Setters
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
 }

--- a/portfolio/src/main/resources/static/index.html
+++ b/portfolio/src/main/resources/static/index.html
@@ -12,6 +12,14 @@
 </head>
 
 <body>
+    <nav>
+        <ul>
+            <li><a href="#intro">Home</a></li>
+            <li><a href="#about">About</a></li>
+            <li><a href="#projects">Projects</a></li>
+            <li><a href="#contact">Contact</a></li>
+        </ul>
+    </nav>
     <header>
         <h1>CoderNawaki</h1>
         <p>Web Developer</p>
@@ -88,16 +96,17 @@
         <!--include contact form or details here-->
         <form id="contactForm">
             <label for="name">Name:</label>
-            <input type="text" id="name" name="name">
+            <input type="text" id="name" name="name" required>
             <br>
             <label for="email">Email:</label>
-            <input type="email" id="email" name="email">
+            <input type="email" id="email" name="email" required>
             <br>
             <label for="message">Message:</label>
-            <textarea id="message" name="message"></textarea>
+            <textarea id="message" name="message" required></textarea>
             <br>
             <button type="submit">Submit</button>
         </form>
+        <p id="formStatus" aria-live="polite"></p>
         <p>Feel free to reach out to me through the following channels:</p>
 
         <ul>

--- a/portfolio/src/main/resources/static/script.js
+++ b/portfolio/src/main/resources/static/script.js
@@ -1,112 +1,123 @@
-//add interactive features smooth scrolling ,form validation etc.
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-document.addEventListener("DOMContentLoaded",function(){
-    const navLinks = document.querySelector('nav a');
+function toggleMenu() {
+    const nav = document.querySelector("nav");
+    if (nav) {
+        nav.classList.toggle("active");
+    }
+}
 
-    navLinks.foreach(link=>{
-        link.addEventListener('click',smoothScroll);
+document.addEventListener("DOMContentLoaded", () => {
+    const navLinks = document.querySelectorAll("nav a");
+    const form = document.getElementById("contactForm");
+    const scrollToTopButton = document.getElementById("scrollToTopBtn");
+    const formStatus = document.getElementById("formStatus");
+
+    navLinks.forEach((link) => {
+        link.addEventListener("click", smoothScroll);
     });
 
-    function smoothScroll(e){
-        e.preventDefault();
+    if (form) {
+        form.addEventListener("submit", validateAndSubmitForm);
+    }
 
-        const targetId = this.getAttribute('href').substring(1);
+    if (scrollToTopButton) {
+        window.addEventListener("scroll", toggleScrollButton);
+        scrollToTopButton.addEventListener("click", () => {
+            window.scrollTo({ top: 0, behavior: "smooth" });
+        });
+        toggleScrollButton();
+    }
 
-        const targetElement = document.getElementById(targetId);
+    function smoothScroll(event) {
+        event.preventDefault();
+        const targetId = this.getAttribute("href")?.substring(1);
+        const targetElement = targetId ? document.getElementById(targetId) : null;
+
+        if (!targetElement) {
+            return;
+        }
 
         window.scrollTo({
-            top:targetElement.offsetTop-60,//adjust the offset if you have a fixed header
-            behavior:'smooth'
+            top: targetElement.offsetTop - 60,
+            behavior: "smooth"
         });
     }
-});
 
-
-//form validation
-document.addEventListener("DOMContentLoaded",function(){
- const form = document.getElementById('contactForm');
- form.addEventListener('submit',validateForm);
-
- function validateForm(e){
- e.preventDefault();
-
- const nameInput = document.getElementById('name');
- const emailInput= document.getElementById('email');
- const messageInput = document.getElementById('message');
-
- if(validateName(nameInput) && validateEmail(emailInput) && validateMessage(messageInput)){
-    //submit the form (you can add a ajax request here or let the form submit naturally.
-    alert('Form submitted successfully.');
-
-     }
-  }
-
-
- function validateName(nameInput){
- const nameValue = nameInput.value.trim();
-     if(nameValue ===''){
-        alert('Please enter your name.');
-        return false;
-     }
-     return true;
- }
-
- function validateEmail(emailInput){
-    const emailValue = emailInput.value.trim();
-
-    const emailRegex = /^[^¥s@]+@[¥s@]+¥.[^¥s@]+$/;
-
-    if(!emailRegex.test(emailValue)){
-        alert('Please enter a  valid email address.');
-        return false;
+    function toggleScrollButton() {
+        const shouldShow = document.body.scrollTop > 10 || document.documentElement.scrollTop > 10;
+        scrollToTopButton.style.display = shouldShow ? "block" : "none";
     }
-    return true;
- }
 
- function validateMessage(messageInput){
- const messageValue = messageInput.value.trim();
-    if(messageValue===''){
-    alert('Please enter a message.');
-        return false;
-    }
-    return true;
- }
+    async function validateAndSubmitForm(event) {
+        event.preventDefault();
 
-});
+        const formData = {
+            name: document.getElementById("name")?.value.trim() ?? "",
+            email: document.getElementById("email")?.value.trim() ?? "",
+            message: document.getElementById("message")?.value.trim() ?? ""
+        };
 
-//scroll event button to top
+        if (!validateName(formData.name) || !validateEmail(formData.email) || !validateMessage(formData.message)) {
+            return;
+        }
 
-document.addEventListener("DOMContentLoaded", function () {
-    // Your existing JavaScript code
+        setFormStatus("Submitting...", false);
 
-    // Scroll-to-top button functionality
-    const scrollToTopButton = document.getElementById("scrollToTopBtn");
+        try {
+            const response = await fetch("/submitContactForm", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify(formData)
+            });
 
-    // Show the button when the user scrolls down 20px from the top
-    window.scroll = function () {
-        scrollFunction();
-    };
+            const payload = await response.json();
 
-    function scrollFunction() {
-        if (document.body.scrollTop > 10 || document.documentElement.scrollTop > 10) {
-            scrollToTopButton.style.display = "block";
-        } else {
-            scrollToTopButton.style.display = "none";
+            if (!response.ok) {
+                setFormStatus(payload.message || "Unable to submit the form.", true);
+                return;
+            }
+
+            form.reset();
+            setFormStatus(payload.message || "Form submitted successfully.", false);
+        } catch (error) {
+            setFormStatus("Unable to submit the form right now. Please try again.", true);
         }
     }
 
-    // Scroll to the top of the page when the button is clicked
-    scrollToTopButton.addEventListener("click", function () {
-        document.body.scrollTop = 0;
-        document.documentElement.scrollTop = 0;
-    });
-
-
-    /* Toggle navigation menu */
-    function toggleMenu(){
-        const nav = document.querySelector('nav');
-        nav.classList.toggle('active');
+    function validateName(nameValue) {
+        if (nameValue === "") {
+            setFormStatus("Please enter your name.", true);
+            return false;
+        }
+        return true;
     }
 
-});
+    function validateEmail(emailValue) {
+        if (!emailRegex.test(emailValue)) {
+            setFormStatus("Please enter a valid email address.", true);
+            return false;
+        }
+        return true;
+    }
 
+    function validateMessage(messageValue) {
+        if (messageValue === "") {
+            setFormStatus("Please enter a message.", true);
+            return false;
+        }
+        return true;
+    }
+
+    function setFormStatus(message, isError) {
+        if (!formStatus) {
+            return;
+        }
+
+        formStatus.textContent = message;
+        formStatus.classList.toggle("error", isError);
+        formStatus.classList.toggle("success", !isError);
+    }
+});


### PR DESCRIPTION
## What changed
- upgraded the Gradle wrapper to 9.4.0 and Spring Boot to 4.0.3 so the project builds on the current Java 25 environment
- removed the unused Lombok annotation processor that was crashing compilation
- fixed the contact form backend validation and returned structured success/error responses
- rewired the frontend contact form to submit JSON to the Spring endpoint and corrected the broken navigation and scroll behavior
- added ignore rules for local IDE and macOS metadata files

## Why this changed
The project was failing before application code could be validated. The original build stack was not compatible with the active Java 25 runtime, and the contact form path had both backend validation bugs and frontend JavaScript errors.

## Impact
- `./gradlew build` now succeeds on Java 25
- the contact form can validate input client-side and submit to `/submitContactForm`
- local `.idea` and `.DS_Store` noise is now ignored for new files

## Root cause
- Gradle 8.5 and Spring Boot 3.2 were not a workable baseline for the current local Java 25 setup
- the email validation logic in the controller rejected valid addresses
- the browser script had multiple runtime issues, including invalid DOM selection and event wiring

## Validation
- ran `./gradlew build` successfully on the updated branch
