### PR TITLE
[codex] Polish portfolio project presentation

### DIFF
--- a/portfolio/src/main/java/com/codernawaki/portfolio/FeaturedProject.java
+++ b/portfolio/src/main/java/com/codernawaki/portfolio/FeaturedProject.java
@@ -7,6 +7,8 @@ public record FeaturedProject(
         String problem,
         String backendFocus,
         String frontendFocus,
+        String outcome,
+        String highlight,
         String githubUrl,
         String visibility,
         String accessNote) {

--- a/portfolio/src/main/java/com/codernawaki/portfolio/HomeController.java
+++ b/portfolio/src/main/java/com/codernawaki/portfolio/HomeController.java
@@ -17,6 +17,16 @@ public class HomeController {
         model.addAttribute("githubUrl", "https://github.com/CoderNawaki");
         model.addAttribute("email", "lama.nawraj00@gmail.com");
         model.addAttribute("resumeLabel", "Resume available on request");
+        model.addAttribute("focusAreas", List.of(
+                "Java and Spring Boot backend delivery",
+                "Frontend implementation with HTML, CSS, JavaScript, and React",
+                "Design documents, testing, and release-oriented development",
+                "Japanese and English communication in engineering environments"));
+        model.addAttribute("proofPoints", List.of(
+                "Working mainly in Japan",
+                "Bridge engineer experience",
+                "Backend-first full stack positioning",
+                "Documentation and testing included in delivery"));
         model.addAttribute("bio",
                 """
                 Professional Java developer working mainly in Japan. Experienced in writing design documents,
@@ -36,6 +46,8 @@ public class HomeController {
                         "Built a business-facing attendance system covering clock-in and clock-out, monthly submission, settings, and account-oriented flows.",
                         "Separated authentication, business logic, and persistence through filters, servlets, services, repositories, and database-backed workflows.",
                         "Delivered JSP-based screens designed for recurring internal usage and operational task flow.",
+                        "Demonstrates enterprise-style layering, business workflow thinking, and operational reliability concerns.",
+                        "Authentication filter, CSRF protection, layered architecture",
                         "https://github.com/CoderNawaki/WebKintaiSystem",
                         "Private",
                         "Repository is private. Architecture and implementation details can be explained in interview or case-study format."),
@@ -46,6 +58,8 @@ public class HomeController {
                         "Built a YouTube-style browsing experience with category feeds, search results, video detail pages, related content, and channel screens.",
                         "Integrated external API data cleanly while keeping the codebase testable and maintainable.",
                         "Focused on responsive browsing, interaction flow, and modern frontend testing with mocked API coverage.",
+                        "Shows frontend delivery with API integration, modern testing, and browser-level verification.",
+                        "RTL, MSW, and Playwright-backed UI confidence",
                         "https://github.com/CoderNawaki/youtube_clone",
                         "Public",
                         "Public repository with frontend and testing workflow visible."),
@@ -56,6 +70,8 @@ public class HomeController {
                         "Refactoring a basic personal site into a structured application that better reflects full stack capability.",
                         "Using Spring Boot controllers and template rendering to move from static content into maintainable, application-style structure.",
                         "Improving layout, navigation, interaction, and project storytelling for stronger hiring impact.",
+                        "Shows the ability to review an existing codebase, stabilize it, and improve both engineering quality and presentation.",
+                        "From static page to template-driven application structure",
                         "https://github.com/CoderNawaki/Portfolio",
                         "Public",
                         "This repository documents the refactor from a simple site into a stronger portfolio application."));

--- a/portfolio/src/main/resources/static/script.js
+++ b/portfolio/src/main/resources/static/script.js
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const form = document.getElementById("contactForm");
     const scrollToTopButton = document.getElementById("scrollToTopBtn");
     const formStatus = document.getElementById("formStatus");
+    const revealElements = document.querySelectorAll(".reveal");
 
     if (menuToggle && siteNav) {
         menuToggle.addEventListener("click", () => {
@@ -48,6 +49,25 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (form) {
         form.addEventListener("submit", validateAndSubmitForm);
+    }
+
+    if ("IntersectionObserver" in window && revealElements.length > 0) {
+        revealElements.forEach((element, index) => {
+            element.style.transitionDelay = `${Math.min(index * 70, 280)}ms`;
+        });
+
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add("is-visible");
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.16 });
+
+        revealElements.forEach((element) => observer.observe(element));
+    } else {
+        revealElements.forEach((element) => element.classList.add("is-visible"));
     }
 
     async function validateAndSubmitForm(event) {

--- a/portfolio/src/main/resources/static/style.css
+++ b/portfolio/src/main/resources/static/style.css
@@ -112,6 +112,17 @@ main {
     padding: 2rem 0;
 }
 
+.reveal {
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.reveal.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
 .hero {
     display: grid;
     grid-template-columns: minmax(0, 1.3fr) minmax(290px, 0.9fr);
@@ -260,6 +271,38 @@ main {
     color: #fff8ef;
 }
 
+.hero-metrics {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.8rem;
+    margin-top: 1.6rem;
+}
+
+.metric-card {
+    padding: 0.95rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.metric-value,
+.metric-label {
+    margin: 0;
+}
+
+.metric-value {
+    color: #fff8ef;
+    font-family: "Space Grotesk", sans-serif;
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.metric-label {
+    margin-top: 0.35rem;
+    color: rgba(255, 248, 239, 0.74);
+    line-height: 1.55;
+}
+
 .panel-title {
     margin-top: 0;
     margin-bottom: 1rem;
@@ -334,11 +377,33 @@ main {
 }
 
 .skill-grid,
-.project-grid,
 .strength-grid,
 .now-grid {
     display: grid;
     gap: 1.25rem;
+}
+
+.proof-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.proof-card {
+    padding: 1rem 1.1rem;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 18px;
+    background: rgba(255, 252, 247, 0.62);
+    box-shadow: 0 14px 34px rgba(58, 46, 33, 0.08);
+    text-align: center;
+}
+
+.proof-label {
+    margin: 0;
+    color: var(--accent-dark);
+    font-size: 0.93rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
 }
 
 .now-grid {
@@ -352,6 +417,26 @@ main {
 .skill-card,
 .strength-card {
     padding: 1.5rem;
+}
+
+.chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    margin-top: 1rem;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.9rem;
+    padding: 0.2rem 0.65rem;
+    border: 1px solid rgba(30, 36, 48, 0.08);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.74);
+    color: var(--accent-dark);
+    font-size: 0.82rem;
+    font-weight: 700;
 }
 
 .now-card {
@@ -378,21 +463,55 @@ main {
     font-size: 1.2rem;
 }
 
-.project-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+.project-showcase {
+    display: grid;
+    gap: 1.35rem;
 }
 
-.project-card {
+.project-case {
+    display: grid;
+    grid-template-columns: minmax(250px, 0.78fr) minmax(0, 1.22fr);
+    gap: 1.2rem;
+    align-items: stretch;
+}
+
+.project-overview,
+.project-body {
+    border: 1px solid rgba(255, 255, 255, 0.52);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(10px);
+}
+
+.project-overview {
     display: flex;
     flex-direction: column;
-    gap: 0.9rem;
     padding: 1.6rem;
+    background: linear-gradient(160deg, rgba(33, 41, 51, 0.96), rgba(102, 56, 35, 0.92));
+    color: #fff8ef;
+}
+
+.project-body {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    padding: 1.6rem;
+    background: rgba(255, 252, 247, 0.72);
 }
 
 .project-topline {
     display: flex;
     flex-wrap: wrap;
     gap: 0.6rem;
+}
+
+.project-index {
+    margin: 1.2rem 0 0.8rem;
+    color: rgba(240, 207, 171, 0.8);
+    font-family: "Space Grotesk", sans-serif;
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1;
 }
 
 .project-visibility,
@@ -416,10 +535,40 @@ main {
     color: var(--muted);
 }
 
+.project-overview .project-stack {
+    background: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 248, 239, 0.82);
+}
+
 .project-tagline {
     color: var(--ink);
     font-size: 1.02rem;
     font-weight: 600;
+}
+
+.project-overview .project-tagline {
+    color: rgba(255, 248, 239, 0.88);
+}
+
+.project-highlight {
+    margin-top: 0.2rem;
+    color: #f8d5b3;
+    font-size: 1rem;
+    line-height: 1.7;
+}
+
+.project-column {
+    padding: 0.25rem 0 0.25rem 1rem;
+    border-left: 3px solid rgba(184, 80, 46, 0.12);
+}
+
+.project-label {
+    margin: 0 0 0.45rem;
+    color: var(--accent-dark);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
 }
 
 .project-details p {
@@ -427,16 +576,25 @@ main {
 }
 
 .project-note {
+    grid-column: 1 / -1;
     padding: 0.85rem 1rem;
     border-radius: 16px;
     background: rgba(30, 36, 48, 0.05);
     font-size: 0.94rem;
 }
 
+.project-note p:last-child {
+    margin: 0;
+}
+
 .project-link {
     margin-top: auto;
     color: var(--accent-dark);
     font-weight: 700;
+}
+
+.project-overview .project-link {
+    color: #fff8ef;
 }
 
 .project-link:hover,
@@ -467,6 +625,32 @@ main {
     margin-top: 1.25rem;
     font-weight: 700;
     color: var(--accent-dark);
+}
+
+.contact-highlight {
+    margin-top: 1.3rem;
+    padding: 1rem 1.1rem;
+    border-radius: 18px;
+    background: rgba(30, 36, 48, 0.05);
+}
+
+.contact-cta-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin-top: 1rem;
+}
+
+.contact-cta-strip span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(184, 80, 46, 0.1);
+    color: var(--accent-dark);
+    font-size: 0.84rem;
+    font-weight: 700;
 }
 
 .contact-form {
@@ -533,7 +717,6 @@ main {
     .about-grid,
     .contact-layout,
     .skill-grid,
-    .project-grid,
     .strength-grid,
     .now-grid {
         grid-template-columns: 1fr 1fr;
@@ -543,10 +726,16 @@ main {
         min-height: auto;
     }
 
-    .project-grid,
+    .proof-grid,
     .strength-grid,
     .skill-grid {
         grid-template-columns: 1fr 1fr;
+    }
+
+    .project-case,
+    .project-body,
+    .hero-metrics {
+        grid-template-columns: 1fr;
     }
 }
 
@@ -581,10 +770,12 @@ main {
     .hero,
     .about-grid,
     .contact-layout,
-    .project-grid,
     .strength-grid,
     .skill-grid,
-    .now-grid {
+    .now-grid,
+    .proof-grid,
+    .project-body,
+    .project-case {
         grid-template-columns: 1fr;
     }
 

--- a/portfolio/src/main/resources/templates/index.html
+++ b/portfolio/src/main/resources/templates/index.html
@@ -27,7 +27,7 @@
 </header>
 
 <main id="top">
-    <section class="hero section">
+    <section class="hero section reveal">
         <div class="hero-copy">
             <p class="eyebrow" th:text="${location}">Working mainly in Japan</p>
             <h1 th:text="${displayName}">Lama Nawaraj</h1>
@@ -45,15 +45,30 @@
         <div class="hero-panel">
             <p class="panel-title">Current focus</p>
             <ul>
-                <li>Java and Spring Boot application development</li>
-                <li>Frontend delivery with HTML, CSS, JavaScript, and React</li>
-                <li>Design documentation, implementation, testing, and deployment</li>
-                <li>Japanese and English communication for bridge engineering work</li>
+                <li th:each="focus : ${focusAreas}" th:text="${focus}">Java and Spring Boot application development</li>
             </ul>
+            <div class="hero-metrics">
+                <article class="metric-card">
+                    <p class="metric-value">Full Stack</p>
+                    <p class="metric-label">Java-first delivery with frontend execution</p>
+                </article>
+                <article class="metric-card">
+                    <p class="metric-value">JP / EN</p>
+                    <p class="metric-label">Communication across Japanese and English contexts</p>
+                </article>
+            </div>
         </div>
     </section>
 
-    <section class="section" id="about">
+    <section class="section proof-section reveal">
+        <div class="proof-grid">
+            <article class="proof-card" th:each="point : ${proofPoints}">
+                <p class="proof-label" th:text="${point}">Working mainly in Japan</p>
+            </article>
+        </div>
+    </section>
+
+    <section class="section reveal" id="about">
         <div class="section-heading">
             <p class="eyebrow">About</p>
             <h2>Backend depth with full stack delivery</h2>
@@ -76,7 +91,7 @@
         </div>
     </section>
 
-    <section class="section now-section">
+    <section class="section now-section reveal">
         <div class="section-heading">
             <p class="eyebrow">Currently Building</p>
             <h2>Work that reflects the next version of my portfolio</h2>
@@ -93,7 +108,7 @@
         </div>
     </section>
 
-    <section class="section" id="skills">
+    <section class="section reveal" id="skills">
         <div class="section-heading">
             <p class="eyebrow">Skills</p>
             <h2>Stack aligned to full stack roles</h2>
@@ -102,47 +117,91 @@
             <article class="skill-card">
                 <h3>Backend</h3>
                 <p>Java, Spring Boot, REST APIs, Gradle, Maven, JPA, application structure, validation, and testing.</p>
+                <div class="chip-row">
+                    <span class="chip">Java</span>
+                    <span class="chip">Spring Boot</span>
+                    <span class="chip">REST APIs</span>
+                    <span class="chip">Gradle</span>
+                </div>
             </article>
             <article class="skill-card">
                 <h3>Frontend</h3>
                 <p>HTML, CSS, JavaScript, React, responsive UI work, and API-driven user interfaces.</p>
+                <div class="chip-row">
+                    <span class="chip">HTML</span>
+                    <span class="chip">CSS</span>
+                    <span class="chip">JavaScript</span>
+                    <span class="chip">React</span>
+                </div>
             </article>
             <article class="skill-card">
                 <h3>Database</h3>
                 <p>H2, SQLite, Oracle, persistence flows, and business-oriented data handling.</p>
+                <div class="chip-row">
+                    <span class="chip">H2</span>
+                    <span class="chip">SQLite</span>
+                    <span class="chip">Oracle</span>
+                    <span class="chip">JPA</span>
+                </div>
             </article>
             <article class="skill-card">
                 <h3>Professional Strengths</h3>
                 <p>Design documentation, testing discipline, deployment awareness, and Japanese business communication.</p>
+                <div class="chip-row">
+                    <span class="chip">Design Docs</span>
+                    <span class="chip">Testing</span>
+                    <span class="chip">Bridge Engineer</span>
+                    <span class="chip">Japanese</span>
+                </div>
             </article>
         </div>
     </section>
 
-    <section class="section" id="projects">
+    <section class="section reveal" id="projects">
         <div class="section-heading">
             <p class="eyebrow">Featured Projects</p>
-            <h2>Selected work that shows both backend and frontend range</h2>
+            <h2>Case studies that show backend depth and frontend execution</h2>
         </div>
-        <div class="project-grid">
-            <article class="project-card" th:each="project : ${projects}">
-                <div class="project-topline">
-                    <span class="project-visibility" th:text="${project.visibility()}">Public</span>
-                    <span class="project-stack" th:text="${project.stack()}">Java, Spring Boot</span>
+        <div class="project-showcase">
+            <article class="project-case" th:each="project, stat : ${projects}">
+                <div class="project-overview">
+                    <div class="project-topline">
+                        <span class="project-visibility" th:text="${project.visibility()}">Public</span>
+                        <span class="project-stack" th:text="${project.stack()}">Java, Spring Boot</span>
+                    </div>
+                    <p class="project-index" th:text="'0' + ${stat.count}">01</p>
+                    <h3 th:text="${project.title()}">Project title</h3>
+                    <p class="project-tagline" th:text="${project.tagline()}">Project tagline</p>
+                    <p class="project-highlight" th:text="${project.highlight()}">Project highlight</p>
+                    <a class="project-link" th:href="${project.githubUrl()}" target="_blank" rel="noreferrer">View Repository</a>
                 </div>
-                <h3 th:text="${project.title()}">Project title</h3>
-                <p class="project-tagline" th:text="${project.tagline()}">Project tagline</p>
-                <p th:text="${project.problem()}">Problem summary</p>
-                <div class="project-details">
-                    <p><strong>Backend:</strong> <span th:text="${project.backendFocus()}">Backend focus</span></p>
-                    <p><strong>Frontend:</strong> <span th:text="${project.frontendFocus()}">Frontend focus</span></p>
+                <div class="project-body">
+                    <div class="project-column">
+                        <p class="project-label">Problem</p>
+                        <p th:text="${project.problem()}">Problem summary</p>
+                    </div>
+                    <div class="project-column">
+                        <p class="project-label">Backend contribution</p>
+                        <p th:text="${project.backendFocus()}">Backend focus</p>
+                    </div>
+                    <div class="project-column">
+                        <p class="project-label">Frontend contribution</p>
+                        <p th:text="${project.frontendFocus()}">Frontend focus</p>
+                    </div>
+                    <div class="project-column">
+                        <p class="project-label">Why it matters</p>
+                        <p th:text="${project.outcome()}">Outcome summary</p>
+                    </div>
+                    <div class="project-note">
+                        <p class="project-label">Access note</p>
+                        <p th:text="${project.accessNote()}">Repository note</p>
+                    </div>
                 </div>
-                <p class="project-note" th:text="${project.accessNote()}">Repository note</p>
-                <a class="project-link" th:href="${project.githubUrl()}" target="_blank" rel="noreferrer">View Repository</a>
             </article>
         </div>
     </section>
 
-    <section class="section strengths-section">
+    <section class="section strengths-section reveal">
         <div class="section-heading">
             <p class="eyebrow">Strengths</p>
             <h2>How I approach delivery</h2>
@@ -163,7 +222,7 @@
         </div>
     </section>
 
-    <section class="section contact-section" id="contact">
+    <section class="section contact-section reveal" id="contact">
         <div class="section-heading">
             <p class="eyebrow">Contact</p>
             <h2>Let’s talk about full stack roles and practical product work</h2>
@@ -174,6 +233,16 @@
                     If you are hiring for a full stack role focused on Java, Spring Boot, and reliable delivery,
                     feel free to reach out.
                 </p>
+                <div class="contact-highlight">
+                    <p class="project-label">Best fit</p>
+                    <p>Full stack roles where backend quality, structured delivery, and communication matter as much as shipping features.</p>
+                </div>
+                <div class="contact-cta-strip">
+                    <span>Java</span>
+                    <span>Spring Boot</span>
+                    <span>Frontend Delivery</span>
+                    <span>Testing</span>
+                </div>
                 <div class="contact-links">
                     <a th:href="${githubUrl}" target="_blank" rel="noreferrer">GitHub</a>
                     <a th:href="'mailto:' + ${email}">Email</a>


### PR DESCRIPTION
## What changed
- strengthened the homepage proof and recruiter-facing summary flow
- upgraded featured projects into richer case-study style presentation blocks
- added clearer skill chips and improved section scanability
- improved hero credibility treatment and closing contact CTA
- added subtle reveal-on-scroll behavior for smoother section pacing

## Why this changed
Phase 1 established the structure and baseline content, but the project presentation still needed stronger visual hierarchy and clearer proof of full stack capability. This update makes the homepage easier to scan and gives each featured project more technical and hiring-facing weight.

## Impact
- the portfolio communicates backend depth and frontend execution more clearly
- featured work now reads more like case studies than generic cards
- the page feels more intentional and polished in the browser
- the existing contact flow and application structure remain intact

## Validation
- ran `./gradlew build`
