### PR TITLE
Add admin authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,12 +23,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/codernawaki/portfolio/SecurityConfig.java
+++ b/src/main/java/com/codernawaki/portfolio/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.codernawaki.portfolio;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/submitContactForm"))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/", "/style.css", "/script.js", "/image.png", "/robots.txt", "/submitContactForm")
+                        .permitAll()
+                        .requestMatchers("/admin/**").authenticated()
+                        .anyRequest().permitAll())
+                .formLogin(Customizer.withDefaults())
+                .logout(logout -> logout.logoutSuccessUrl("/"));
+
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(
+            @Value("${portfolio.admin.username}") String username,
+            @Value("${portfolio.admin.password}") String password,
+            PasswordEncoder passwordEncoder) {
+        UserDetails adminUser = User.withUsername(username)
+                .password(passwordEncoder.encode(password))
+                .roles("ADMIN")
+                .build();
+
+        return new InMemoryUserDetailsManager(adminUser);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 server.port=8081
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
+portfolio.admin.username=${PORTFOLIO_ADMIN_USERNAME:admin}
+portfolio.admin.password=${PORTFOLIO_ADMIN_PASSWORD:change-me-now}

--- a/src/main/resources/templates/admin/contact-submissions.html
+++ b/src/main/resources/templates/admin/contact-submissions.html
@@ -60,6 +60,7 @@
                         <form class="submission-update-form"
                               th:action="@{/admin/contact-submissions/{submissionId}(submissionId=${submission.id})}"
                               method="post">
+                            <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                             <label>
                                 <span>Status</span>
                                 <select name="status">

--- a/src/test/java/com/codernawaki/portfolio/SecurityConfigTest.java
+++ b/src/test/java/com/codernawaki/portfolio/SecurityConfigTest.java
@@ -1,0 +1,91 @@
+package com.codernawaki.portfolio;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+class SecurityConfigTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private ContactSubmissionRepository contactSubmissionRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        contactSubmissionRepository.deleteAll();
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    void shouldRedirectUnauthenticatedAdminAccessToLogin() throws Exception {
+        mockMvc.perform(get("/admin/contact-submissions"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/login"));
+    }
+
+    @Test
+    void shouldAllowAuthenticatedAdminAccess() throws Exception {
+        mockMvc.perform(get("/admin/contact-submissions")
+                        .with(user("admin").roles("ADMIN")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldAllowPublicContactSubmissionWithoutCsrfToken() throws Exception {
+        mockMvc.perform(post("/submitContactForm")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "Lama",
+                                  "email": "lama@example.com",
+                                  "message": "Interested in discussing a role."
+                                }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldRejectAdminUpdateWithoutCsrfToken() throws Exception {
+        mockMvc.perform(post("/admin/contact-submissions/1")
+                        .with(user("admin").roles("ADMIN"))
+                        .param("status", "REVIEWED")
+                        .param("adminNote", "Checked."))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldAllowAdminUpdateWithCsrfToken() throws Exception {
+        ContactSubmission submission = new ContactSubmission();
+        submission.setName("Lama");
+        submission.setEmail("lama@example.com");
+        submission.setMessage("Interested in discussing a role.");
+        submission.setStatus(ContactSubmissionStatus.NEW);
+        ContactSubmission savedSubmission = contactSubmissionRepository.save(submission);
+
+        mockMvc.perform(post("/admin/contact-submissions/" + savedSubmission.getId())
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf())
+                        .param("status", "REVIEWED")
+                        .param("adminNote", "Checked."))
+                .andExpect(status().is3xxRedirection());
+    }
+}


### PR DESCRIPTION
Summary
  Implemented admin authentication for the portfolio admin area using
  Spring Security. Public pages and contact submission remain
  accessible, while /admin/** now requires login.

  Changes

  - Added Spring Security configuration with form-based login/logout
  - Protected admin routes behind authentication
  - Added configurable admin credentials via application properties/
    environment variables
  - Updated the admin submission form to include CSRF protection
  - Added integration tests covering login protection and CSRF
    behavior