### PR TITLE
Require admin credentials from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ This project is used as both a recruiter-facing portfolio site and a demonstrati
 From the repository root:
 
 ```bash
+export PORTFOLIO_ADMIN_USERNAME=your-admin-username
+export PORTFOLIO_ADMIN_PASSWORD=your-admin-password
 ./gradlew bootRun
 ```
 
@@ -45,6 +47,12 @@ The app runs locally at:
 
 ```text
 http://localhost:8081/
+```
+
+Admin login:
+
+```text
+http://localhost:8081/login
 ```
 
 ## Build And Test
@@ -97,3 +105,4 @@ Repository:
 
 - `plan.md` is intentionally kept local and ignored from Git.
 - The application currently uses port `8081` to avoid local conflicts with `8080`.
+- The app now requires `PORTFOLIO_ADMIN_USERNAME` and `PORTFOLIO_ADMIN_PASSWORD` to start.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port=8081
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
-portfolio.admin.username=${PORTFOLIO_ADMIN_USERNAME:admin}
-portfolio.admin.password=${PORTFOLIO_ADMIN_PASSWORD:change-me-now}
+portfolio.admin.username=${PORTFOLIO_ADMIN_USERNAME}
+portfolio.admin.password=${PORTFOLIO_ADMIN_PASSWORD}

--- a/src/test/java/com/codernawaki/portfolio/PortfolioApplicationTests.java
+++ b/src/test/java/com/codernawaki/portfolio/PortfolioApplicationTests.java
@@ -3,7 +3,10 @@ package com.codernawaki.portfolio;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+		"PORTFOLIO_ADMIN_USERNAME=test-admin",
+		"PORTFOLIO_ADMIN_PASSWORD=test-password"
+})
 class PortfolioApplicationTests {
 
 	@Test

--- a/src/test/java/com/codernawaki/portfolio/SecurityConfigTest.java
+++ b/src/test/java/com/codernawaki/portfolio/SecurityConfigTest.java
@@ -17,7 +17,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+        "PORTFOLIO_ADMIN_USERNAME=test-admin",
+        "PORTFOLIO_ADMIN_PASSWORD=test-password"
+})
 class SecurityConfigTest {
 
     @Autowired


### PR DESCRIPTION
PR Summary

  This PR hardens admin authentication configuration by
  removing insecure fallback credentials and requiring
  explicit environment-based admin credentials at startup. It
  also updates test configuration and local setup
  documentation so the stricter auth setup remains predictable
  in development and CI.

  Changes

  - Removed default fallback values for
    PORTFOLIO_ADMIN_USERNAME and PORTFOLIO_ADMIN_PASSWORD
  - Made the application require admin credentials from the
    environment on startup
  - Added test-only admin credential properties for Spring
    Boot context tests
  - Updated local run documentation with required environment
    variables and admin login URL

  Why

  - Prevents the app from booting with a known default admin
    password
  - Aligns the admin login flow with safer production-style
    configuration
  - Keeps automated tests stable without depending on external
    shell configuration
