### PR TITLE
Migrate to PostgreSQL, Implement Swagger UI, and Enable Structured Logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
 	runtimeOnly 'com.h2database:h2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
       - portfolio-network
     depends_on:
       - db
+    logging:
+      driver: "json-file"
+      options:
+        tag: "{{.Name}}"
 
   db:
     image: postgres:16-alpine
@@ -46,6 +50,26 @@ services:
       - portfolio-network
     depends_on:
       - prometheus
+      - loki
+
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - portfolio-network
+
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ./promtail-config.yml:/etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml
+    networks:
+      - portfolio-network
+    depends_on:
+      - loki
 
 networks:
   portfolio-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,10 @@ services:
 
   promtail:
     image: grafana/promtail:latest
+    user: root
     volumes:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./promtail-config.yml:/etc/promtail/config.yml
     command: -config.file=/etc/promtail/config.yml
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   portfolio-app:
     build: .
@@ -15,7 +13,6 @@ services:
       - portfolio-network
     depends_on:
       - db
-      - prometheus
 
   db:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,7 @@ services:
       retries: 5
 
   prometheus:
-...
-
+    image: prom/prometheus
     ports:
       - "9090:9090"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,23 @@ services:
     environment:
       - PORTFOLIO_ADMIN_USERNAME=${PORTFOLIO_ADMIN_USERNAME}
       - PORTFOLIO_ADMIN_PASSWORD=${PORTFOLIO_ADMIN_PASSWORD}
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/portfolio
+      - SPRING_DATASOURCE_USERNAME=portfolio_user
+      - SPRING_DATASOURCE_PASSWORD=portfolio_pass
+    networks:
+      - portfolio-network
+    depends_on:
+      - db
+      - prometheus
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_DB=portfolio
+      - POSTGRES_USER=portfolio_user
+      - POSTGRES_PASSWORD=portfolio_pass
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
     networks:
       - portfolio-network
 
@@ -39,3 +56,4 @@ networks:
 
 volumes:
   grafana-storage:
+  postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     networks:
       - portfolio-network
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     logging:
       driver: "json-file"
       options:
@@ -28,9 +29,15 @@ services:
       - postgres-data:/var/lib/postgresql/data
     networks:
       - portfolio-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U portfolio_user -d portfolio"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   prometheus:
-    image: prom/prometheus
+...
+
     ports:
       - "9090:9090"
     volumes:

--- a/promtail-config.yml
+++ b/promtail-config.yml
@@ -1,0 +1,27 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: system
+    static_configs:
+    - targets:
+        - localhost
+      labels:
+        job: varlogs
+        __path__: /var/log/*log
+
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'container'

--- a/src/main/java/com/codernawaki/portfolio/SecurityConfig.java
+++ b/src/main/java/com/codernawaki/portfolio/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/style.css", "/script.js", "/image.png", "/robots.txt").permitAll()
                         .requestMatchers("/", "/login", "/submitContactForm", "/actuator/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .formLogin(login -> login

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,14 @@
 server.port=8081
+
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:h2:mem:portfoliodb}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:sa}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
+spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER:org.h2.Driver}
+
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.dialect=${SPRING_JPA_DIALECT:org.hibernate.dialect.H2Dialect}
+
 portfolio.admin.username=${PORTFOLIO_ADMIN_USERNAME}
 portfolio.admin.password=${PORTFOLIO_ADMIN_PASSWORD}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,11 +3,9 @@ server.port=8081
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:h2:mem:portfoliodb}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:sa}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
-spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER:org.h2.Driver}
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
-spring.jpa.properties.hibernate.dialect=${SPRING_JPA_DIALECT:org.hibernate.dialect.H2Dialect}
 
 portfolio.admin.username=${PORTFOLIO_ADMIN_USERNAME}
 portfolio.admin.password=${PORTFOLIO_ADMIN_PASSWORD}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Description
  This PR significantly matures the application infrastructure by moving to a persistent database, adding interactive API documentation, and
  completing the observability stack with centralized, structured logging.

  Key Changes

  🗄️ Data Persistence (PostgreSQL Migration)
   * Postgres Integration: Added a PostgreSQL container to the Docker stack with persistent volume mapping.
   * Dual-Database Support: Configured application.properties with a smart fallback mechanism. The app now automatically detects and uses
     PostgreSQL when running in Docker, while maintaining H2 support for rapid local development.
   * Auto-Detection: Removed hardcoded driver and dialect settings to allow Spring Boot to auto-configure based on the active JDBC URL.

  📖 API Documentation (Swagger/OpenAPI)
   * Interactive UI: Integrated SpringDoc OpenAPI to provide a dynamic Swagger UI.
   * Endpoints: Exposed /swagger-ui/index.html for API exploration and /v3/api-docs for raw OpenAPI specifications.
   * Security Alignment: Updated SecurityConfig to permit public access to these documentation paths.

  🪵 Log Aggregation (Loki & JSON Logging)
   * Loki & Promtail: Added Grafana Loki (log database) and Promtail (log agent) to the docker-compose environment.
   * Structured Logging: Implemented logstash-logback-encoder to output logs in JSON format. This allows for high-performance searching and
     filtering in Grafana based on fields like level, logger, and thread.
   * Dashboard Integration: Enabled the ability to query logs directly in Grafana using LogQL (e.g., {container="portfolio-app"} | json).

  How to Verify
   1. Start the environment:

   1     docker-compose up --build
   2. Verify Database: Check the logs to ensure the app connects to jdbc:postgresql://db:5432/portfolio.
   3. Verify Swagger: Visit http://localhost:8081/swagger-ui/index.html to see the interactive API docs.
   4. Verify Logs: In Grafana (http://localhost:3000), add a Loki Data Source (URL: http://loki:3100) and use the Explore tab to view the new
      JSON-formatted logs.