### PR TITLE
Add SEO metadata and project case study pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Spring Boot portfolio application for Lama Nawaraj, a full stack developer working mainly in Japan.
 
-This project is used as both a recruiter-facing portfolio site and a demonstration of iterative full stack improvement with Java, Spring Boot, template rendering, frontend polish, and tested contact handling.
+This project is a recruiter-facing portfolio application built to present Lama Nawaraj as a Java-first full stack developer working mainly in Japan. It also serves as a public engineering sample showing iterative improvement across backend structure, admin workflows, observability, and presentation quality.
 
 ## Highlights
 
@@ -11,11 +11,13 @@ This project is used as both a recruiter-facing portfolio site and a demonstrati
 - **Architectural Excellence**: Layered architecture with dedicated services, properties-backed configuration, and global model advice.
 - **Thymeleaf Fragments**: Reusable template components for a consistent UI across all pages.
 - **Validated Contact Flow**: Structured API responses with server-side validation.
+- **Case Study Pages**: Featured projects now have dedicated detail pages instead of dead outbound-only links.
 - **Admin Dashboard**: Protected area to review, search, and manage contact submissions.
 - **Responsive UI**: Modern design with section navigation and progressive reveal effects.
 - **Operational Visibility**: Prometheus metrics, Loki logs, Tempo traces, and a provisioned Grafana dashboard for runtime inspection.
 - **Security & Resilience**: Redis-backed rate limiting with fallback to in-memory buckets.
 - **Database Evolution**: Flyway-based schema migrations for reproducible database state.
+- **SEO & Share Metadata**: Canonical links, Open Graph/Twitter metadata, robots rules, sitemap, and manifest-backed web metadata.
 
 ## Tech Stack
 
@@ -59,6 +61,12 @@ This project is used as both a recruiter-facing portfolio site and a demonstrati
    - Portfolio: `http://localhost:8081/`
    - Admin Login: `http://localhost:8081/login`
 
+4. **Optional Public URL Configuration**:
+   For correct canonical and share metadata outside local development:
+   ```bash
+   export PORTFOLIO_SITE_URL=https://your-public-domain.example
+   ```
+
 ## Configuration
 
 You can update the portfolio content without changing Java code by editing `src/main/resources/application.properties`.
@@ -78,6 +86,12 @@ portfolio.projects[0].title=New Project
 ```bash
 ./gradlew build
 ```
+
+## Recruiter-Facing Pages
+
+- Home page: portfolio overview, skills, and featured projects
+- Project case study pages: `/projects/{slug}`
+- Admin inbox: secure review and management of contact submissions
 
 ## Monitoring Stack
 

--- a/src/main/java/com/codernawaki/portfolio/GlobalModelAttributeAdvice.java
+++ b/src/main/java/com/codernawaki/portfolio/GlobalModelAttributeAdvice.java
@@ -18,8 +18,15 @@ public class GlobalModelAttributeAdvice {
     public void addGlobalAttributes(Model model) {
         PortfolioProperties props = portfolioService.getProperties();
         model.addAttribute("displayName", props.getDisplayName());
+        model.addAttribute("siteUrl", props.getSiteUrl());
         model.addAttribute("githubUrl", props.getGithubUrl());
         model.addAttribute("email", props.getEmail());
         model.addAttribute("currentYear", Year.now().getValue());
+        model.addAttribute("defaultSocialImageUrl", props.getSiteUrl() + "/image.png");
+        model.addAttribute("pageTitle", props.getDisplayName() + " | Full Stack Developer in Japan");
+        model.addAttribute("pageDescription",
+                "Java-first full stack developer portfolio featuring Spring Boot delivery, frontend execution, and project work in Japan.");
+        model.addAttribute("pageUrl", props.getSiteUrl() + "/");
+        model.addAttribute("pageImageUrl", props.getSiteUrl() + "/image.png");
     }
 }

--- a/src/main/java/com/codernawaki/portfolio/HomeController.java
+++ b/src/main/java/com/codernawaki/portfolio/HomeController.java
@@ -2,7 +2,11 @@ package com.codernawaki.portfolio;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 @Controller
 public class HomeController {
@@ -16,7 +20,7 @@ public class HomeController {
     @GetMapping("/")
     public String home(Model model) {
         PortfolioProperties props = portfolioService.getProperties();
-        
+
         model.addAttribute("role", props.getRole());
         model.addAttribute("location", props.getLocation());
         model.addAttribute("resumeLabel", props.getResumeLabel());
@@ -25,12 +29,56 @@ public class HomeController {
         model.addAttribute("proofPoints", props.getProofPoints());
         model.addAttribute("bio", props.getBio());
         model.addAttribute("projects", portfolioService.getFeaturedProjects());
-        
+        model.addAttribute("pageTitle", props.getDisplayName() + " | Full Stack Developer Portfolio");
+        model.addAttribute("pageDescription",
+                "Portfolio of Lama Nawaraj, a Java-first full stack developer in Japan covering Spring Boot, frontend delivery, testing, and recruiter-ready project case studies.");
+        model.addAttribute("pageUrl", props.getSiteUrl() + "/");
         return "index";
     }
 
+    @GetMapping("/projects/{slug}")
+    public String projectDetail(@PathVariable String slug, Model model) {
+        FeaturedProject project = portfolioService.findProjectBySlug(slug)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Project not found."));
+        PortfolioProperties props = portfolioService.getProperties();
+
+        model.addAttribute("project", project);
+        model.addAttribute("pageTitle", project.title() + " | Case Study | " + props.getDisplayName());
+        model.addAttribute("pageDescription", project.tagline() + " Built with " + project.stack() + ".");
+        model.addAttribute("pageUrl", props.getSiteUrl() + "/projects/" + project.slug());
+        return "project-detail";
+    }
+
     @GetMapping("/login")
-    public String login() {
+    public String login(Model model) {
+        PortfolioProperties props = portfolioService.getProperties();
+        model.addAttribute("pageTitle", "Admin Login | " + props.getDisplayName());
+        model.addAttribute("pageDescription", "Secure admin login for reviewing portfolio contact submissions.");
+        model.addAttribute("pageUrl", props.getSiteUrl() + "/login");
         return "login";
+    }
+
+    @GetMapping(value = "/sitemap.xml", produces = "application/xml")
+    @ResponseBody
+    public String sitemap() {
+        PortfolioProperties props = portfolioService.getProperties();
+        String baseUrl = props.getSiteUrl();
+
+        StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">");
+        appendSitemapUrl(xml, baseUrl + "/");
+        appendSitemapUrl(xml, baseUrl + "/login");
+        for (FeaturedProject project : portfolioService.getFeaturedProjects()) {
+            appendSitemapUrl(xml, baseUrl + "/projects/" + project.slug());
+        }
+        xml.append("</urlset>");
+        return xml.toString();
+    }
+
+    private void appendSitemapUrl(StringBuilder xml, String url) {
+        xml.append("<url><loc>")
+                .append(url)
+                .append("</loc></url>");
     }
 }

--- a/src/main/java/com/codernawaki/portfolio/PortfolioProperties.java
+++ b/src/main/java/com/codernawaki/portfolio/PortfolioProperties.java
@@ -11,6 +11,7 @@ public class PortfolioProperties {
     private String displayName;
     private String role;
     private String location;
+    private String siteUrl;
     private String githubUrl;
     private String email;
     private String resumeLabel;
@@ -28,6 +29,9 @@ public class PortfolioProperties {
 
     public String getLocation() { return location; }
     public void setLocation(String location) { this.location = location; }
+
+    public String getSiteUrl() { return siteUrl; }
+    public void setSiteUrl(String siteUrl) { this.siteUrl = siteUrl; }
 
     public String getGithubUrl() { return githubUrl; }
     public void setGithubUrl(String githubUrl) { this.githubUrl = githubUrl; }

--- a/src/main/java/com/codernawaki/portfolio/PortfolioService.java
+++ b/src/main/java/com/codernawaki/portfolio/PortfolioService.java
@@ -1,6 +1,7 @@
 package com.codernawaki.portfolio;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -36,5 +37,11 @@ public class PortfolioService {
                         p.getAccessNote()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    public Optional<FeaturedProject> findProjectBySlug(String slug) {
+        return getFeaturedProjects().stream()
+                .filter(project -> project.slug().equals(slug))
+                .findFirst();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,7 @@ portfolio.admin.password=${PORTFOLIO_ADMIN_PASSWORD}
 portfolio.display-name=Lama Nawaraj
 portfolio.role=Full Stack Developer
 portfolio.location=Working mainly in Japan
+portfolio.site-url=${PORTFOLIO_SITE_URL:http://localhost:8081}
 portfolio.github-url=https://github.com/CoderNawaki
 portfolio.email=lama.nawraj00@gmail.com
 portfolio.resume-label=Resume available on request
@@ -48,8 +49,8 @@ portfolio.focus-areas=Java and Spring Boot backend delivery, Frontend implementa
 portfolio.proof-points=Working mainly in Japan, Bridge engineer experience, Backend-first full stack positioning, Documentation and testing included in delivery
 portfolio.bio=Professional Java developer working mainly in Japan. Experienced in writing design documents, development, and testing. Strong language proficiency in Japanese, with English as a secondary language. Experienced in bridge engineer work and committed to learning new technology every day.
 
-portfolio.projects[0].slug=web-kintai-system
 portfolio.projects[0].title=WebKintaiSystem
+portfolio.projects[0].slug=webkintaisystem
 portfolio.projects[0].tagline=Attendance platform for day-to-day operations, submission control, and business workflow reliability
 portfolio.projects[0].stack=Java, Servlet, JSP, Maven, Jetty, H2, SQLite, Oracle
 portfolio.projects[0].problem=Built a business-facing attendance system covering clock-in and clock-out, monthly submission, settings, and account-oriented flows.
@@ -61,8 +62,8 @@ portfolio.projects[0].github-url=https://github.com/CoderNawaki/WebKintaiSystem
 portfolio.projects[0].visibility=Private
 portfolio.projects[0].access-note=Repository is private. Architecture and implementation details can be explained in interview or case-study format.
 
-portfolio.projects[1].slug=youtube-clone
 portfolio.projects[1].title=YouTube Clone
+portfolio.projects[1].slug=youtube-clone
 portfolio.projects[1].tagline=Frontend product clone focused on search, discovery, testing, and API-driven user experience
 portfolio.projects[1].stack=React, JavaScript, RapidAPI, React Testing Library, MSW, Playwright
 portfolio.projects[1].problem=Built a YouTube-style browsing experience with category feeds, search results, video detail pages, related content, and channel screens.
@@ -74,8 +75,8 @@ portfolio.projects[1].github-url=https://github.com/CoderNawaki/youtube_clone
 portfolio.projects[1].visibility=Public
 portfolio.projects[1].access-note=Public repository with frontend and testing workflow visible.
 
-portfolio.projects[2].slug=portfolio
 portfolio.projects[2].title=Portfolio
+portfolio.projects[2].slug=portfolio
 portfolio.projects[2].tagline=Spring Boot portfolio rebuild showing full stack delivery, structure improvement, and recruiter-focused presentation
 portfolio.projects[2].stack=Java, Spring Boot, Gradle, HTML, CSS, JavaScript
 portfolio.projects[2].problem=Refactoring a basic personal site into a structured application that better reflects full stack capability.

--- a/src/main/resources/static/robots.txt
+++ b/src/main/resources/static/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: /sitemap.xml

--- a/src/main/resources/static/site.webmanifest
+++ b/src/main/resources/static/site.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Lama Nawaraj Portfolio",
+  "short_name": "Lama Portfolio",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f4efe5",
+  "theme_color": "#b8502e",
+  "icons": [
+    {
+      "src": "/image.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -372,12 +372,51 @@ main { padding: 2rem 0 5rem; }
     opacity: 0.5;
 }
 
+.project-detail-main {
+    width: min(calc(100% - 2rem), var(--content-width));
+    margin: 0 auto;
+    padding: 2rem 0 5rem;
+}
+
+.project-detail-hero,
+.project-detail-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.project-detail-hero {
+    grid-template-columns: 1.25fr 0.75fr;
+}
+
+.project-detail-intro,
+.project-detail-card {
+    border: 1px solid rgba(255, 255, 255, 0.52);
+    border-radius: var(--radius-xl);
+    background: var(--bg-panel);
+    box-shadow: var(--shadow);
+    padding: 1.75rem;
+}
+
+.project-detail-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.project-detail-tagline {
+    font-size: 1.2rem;
+    color: var(--muted);
+    line-height: 1.7;
+}
+
 @media (max-width: 760px) {
     .admin-header-topline,
     .admin-table-header,
     .admin-pagination {
         flex-direction: column;
         align-items: stretch;
+    }
+    .project-detail-hero,
+    .project-detail-grid {
+        grid-template-columns: 1fr;
     }
 }
 

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -3,22 +3,29 @@
 <head th:fragment="head">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title th:text="${displayName} + ' | Full Stack Developer'">Lama Nawaraj | Full Stack Developer</title>
-    <meta name="description"
+    <title th:text="${pageTitle}">Lama Nawaraj | Full Stack Developer in Japan</title>
+    <meta name="description" th:content="${pageDescription}"
           content="Full stack developer portfolio for Lama Nawaraj featuring Java, Spring Boot, frontend delivery, and project work in Japan.">
     <meta name="author" content="Lama Nawaraj">
     <meta name="theme-color" content="#b8502e">
-    <meta property="og:title" content="Lama Nawaraj | Full Stack Developer">
-    <meta property="og:description"
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" th:href="${pageUrl}">
+    <link rel="icon" type="image/png" th:href="@{/image.png}">
+    <link rel="apple-touch-icon" th:href="@{/image.png}">
+    <link rel="manifest" th:href="@{/site.webmanifest}">
+    <meta property="og:site_name" th:content="${displayName}">
+    <meta property="og:title" th:content="${pageTitle}" content="Lama Nawaraj | Full Stack Developer">
+    <meta property="og:description" th:content="${pageDescription}"
           content="Full stack developer portfolio featuring Java, Spring Boot, frontend delivery, and project work in Japan.">
     <meta property="og:type" content="website">
-    <meta property="og:image" th:content="@{/image.png}">
+    <meta property="og:url" th:content="${pageUrl}">
+    <meta property="og:image" th:content="${pageImageUrl}">
     <meta property="og:locale" content="en_US">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Lama Nawaraj | Full Stack Developer">
-    <meta name="twitter:description"
+    <meta name="twitter:title" th:content="${pageTitle}" content="Lama Nawaraj | Full Stack Developer">
+    <meta name="twitter:description" th:content="${pageDescription}"
           content="Full stack developer portfolio featuring Java, Spring Boot, frontend delivery, and project work in Japan.">
-    <meta name="twitter:image" th:content="@{/image.png}">
+    <meta name="twitter:image" th:content="${pageImageUrl}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap"

--- a/src/main/resources/templates/project-detail.html
+++ b/src/main/resources/templates/project-detail.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments :: head}"></head>
+<body>
+<header th:replace="~{fragments :: header}"></header>
+
+<main class="project-detail-main">
+    <section class="project-detail-hero section reveal">
+        <div class="project-detail-intro">
+            <p class="eyebrow">Case Study</p>
+            <h1 th:text="${project.title()}">Project title</h1>
+            <p class="project-detail-tagline" th:text="${project.tagline()}">Project tagline</p>
+            <div class="chip-row">
+                <span class="chip" th:text="${project.visibility()}">Public</span>
+                <span class="chip" th:text="${project.stack()}">Java, Spring Boot</span>
+            </div>
+            <div class="hero-actions">
+                <a class="button button-primary" th:href="${project.githubUrl()}" target="_blank" rel="noreferrer">View Repository</a>
+                <a class="button button-secondary" th:href="@{/#projects}">Back to Portfolio</a>
+            </div>
+        </div>
+        <div class="hero-panel">
+            <p class="panel-title">Why this project matters</p>
+            <p th:text="${project.highlight()}">Project highlight</p>
+            <p th:text="${project.outcome()}">Outcome summary</p>
+        </div>
+    </section>
+
+    <section class="section project-detail-grid reveal">
+        <article class="project-detail-card">
+            <p class="project-label">Problem</p>
+            <p th:text="${project.problem()}">Problem statement</p>
+        </article>
+        <article class="project-detail-card">
+            <p class="project-label">Backend contribution</p>
+            <p th:text="${project.backendFocus()}">Backend focus</p>
+        </article>
+        <article class="project-detail-card">
+            <p class="project-label">Frontend contribution</p>
+            <p th:text="${project.frontendFocus()}">Frontend focus</p>
+        </article>
+        <article class="project-detail-card">
+            <p class="project-label">Access note</p>
+            <p th:text="${project.accessNote()}">Repository note</p>
+        </article>
+    </section>
+</main>
+
+<footer th:replace="~{fragments :: footer}"></footer>
+</body>
+</html>

--- a/src/test/java/com/codernawaki/portfolio/HomeControllerTest.java
+++ b/src/test/java/com/codernawaki/portfolio/HomeControllerTest.java
@@ -1,0 +1,109 @@
+package com.codernawaki.portfolio;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.ViewResolver;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.view.ThymeleafViewResolver;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+class HomeControllerTest {
+
+    private MockMvc mockMvc;
+    private PortfolioService portfolioService;
+    private PortfolioProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new PortfolioProperties();
+        properties.setDisplayName("Lama Nawaraj");
+        properties.setRole("Full Stack Developer");
+        properties.setLocation("Working mainly in Japan");
+        properties.setResumeLabel("Resume available on request");
+        properties.setAvailability("Open to full stack opportunities.");
+        properties.setBio("Professional Java developer.");
+        properties.setFocusAreas(List.of("Java and Spring Boot"));
+        properties.setProofPoints(List.of("Working mainly in Japan"));
+        properties.setGithubUrl("https://github.com/CoderNawaki");
+        properties.setEmail("lama@example.com");
+        properties.setSiteUrl("http://localhost:8081");
+        PortfolioProperties.FeaturedProjectProperties project = new PortfolioProperties.FeaturedProjectProperties();
+        project.setSlug("portfolio");
+        project.setTitle("Portfolio");
+        project.setTagline("Structured Spring Boot portfolio rebuild");
+        project.setStack("Java, Spring Boot");
+        project.setProblem("Refactoring a basic personal site.");
+        project.setBackendFocus("Backend restructuring.");
+        project.setFrontendFocus("Frontend improvement.");
+        project.setOutcome("Stronger recruiter-facing presentation.");
+        project.setHighlight("Template-driven application structure");
+        project.setGithubUrl("https://github.com/CoderNawaki/Portfolio");
+        project.setVisibility("Public");
+        project.setAccessNote("Public repository");
+        properties.setProjects(List.of(project));
+
+        portfolioService = new PortfolioService(properties);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new HomeController(portfolioService))
+                .setControllerAdvice(new GlobalModelAttributeAdvice(portfolioService))
+                .setViewResolvers(thymeleafViewResolver())
+                .build();
+    }
+
+    @Test
+    void shouldRenderHomePageWithSeoMetadata() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"))
+                .andExpect(model().attribute("pageTitle", "Lama Nawaraj | Full Stack Developer Portfolio"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("rel=\"canonical\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("summary_large_image")));
+    }
+
+    @Test
+    void shouldRenderProjectDetailPage() throws Exception {
+        mockMvc.perform(get("/projects/portfolio"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("project-detail"))
+                .andExpect(model().attributeExists("project"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("Case Study")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("Structured Spring Boot portfolio rebuild")));
+    }
+
+    @Test
+    void shouldRenderSitemapFromConfiguredSiteUrl() throws Exception {
+        mockMvc.perform(get("/sitemap.xml"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/xml"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("<loc>http://localhost:8081/</loc>")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("<loc>http://localhost:8081/login</loc>")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("<loc>http://localhost:8081/projects/portfolio</loc>")));
+    }
+
+    private ViewResolver thymeleafViewResolver() {
+        ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+        templateResolver.setPrefix("templates/");
+        templateResolver.setSuffix(".html");
+        templateResolver.setTemplateMode(TemplateMode.HTML);
+        templateResolver.setCharacterEncoding("UTF-8");
+
+        SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.setTemplateResolver(templateResolver);
+
+        ThymeleafViewResolver viewResolver = new ThymeleafViewResolver();
+        viewResolver.setTemplateEngine(templateEngine);
+        viewResolver.setCharacterEncoding("UTF-8");
+        viewResolver.setOrder(1);
+        return viewResolver;
+    }
+}


### PR DESCRIPTION

  ## Summary

  This PR improves the portfolio’s recruiter-facing presentation by adding page-level SEO metadata, project case study pages, and search-engine
  discovery files.

  ## What Changed

  - Added dynamic SEO metadata support for page title, description, canonical URL, and social sharing tags
  - Added recruiter-facing project detail pages at /projects/{slug}
  - Added slug-based project lookup in the portfolio service
  - Added portfolio.site-url configuration to build environment-correct absolute URLs
  - Added robots.txt sitemap reference
  - Added site.webmanifest for installable/app metadata
  - Replaced the hardcoded static sitemap with a dynamic /sitemap.xml endpoint
  - Added controller test coverage for homepage SEO, project detail page rendering, and sitemap output
  - Updated the README with recruiter-facing and SEO-related documentation

  ## Why

  The site already showed project summaries, but it did not have strong page-specific metadata or dedicated case study pages. This change makes the
  portfolio more shareable, more indexable, and more useful as a hiring artifact.

  ## Implementation Notes

  - Slugs are now the stable URL identifiers for project pages
  - Sitemap URLs are generated from portfolio.site-url instead of hardcoded localhost values
  - Duplicate slug entries in application.properties were removed so each project has one canonical slug

  ## Testing

  - Ran ./gradlew test
  - Added HomeControllerTest coverage for:
      - homepage SEO metadata
      - project detail page rendering
      - sitemap generation

  ## Follow-up

  - Replace local portfolio.site-url with the real deployed domain in production env config
  - Continue with phase 2: admin UX refinement