### PR TITLE
Refine admin contact submission workflow and inbox UX

### DIFF
--- a/src/main/java/com/codernawaki/portfolio/AdminController.java
+++ b/src/main/java/com/codernawaki/portfolio/AdminController.java
@@ -27,17 +27,22 @@ public class AdminController {
     public String contactSubmissions(
             @RequestParam(defaultValue = "") String query,
             @RequestParam(required = false) ContactSubmissionStatus status,
+            @RequestParam(defaultValue = "NEWEST") AdminSubmissionSort sort,
+            @RequestParam(required = false) Long selected,
             @RequestParam(defaultValue = "0") int page,
             Model model) {
         int safePage = Math.max(page, 0);
         Page<ContactSubmission> submissionsPage = contactService.findSubmissions(
-                query, status, PageRequest.of(safePage, SUBMISSIONS_PER_PAGE));
+                query, status, PageRequest.of(safePage, SUBMISSIONS_PER_PAGE, sort.toSort()));
 
         model.addAttribute("submissionsPage", submissionsPage);
         model.addAttribute("submissions", submissionsPage.getContent());
         model.addAttribute("availableStatuses", ContactSubmissionStatus.values());
+        model.addAttribute("availableSorts", AdminSubmissionSort.values());
         model.addAttribute("currentQuery", query);
         model.addAttribute("currentStatus", status == null ? "" : status.name());
+        model.addAttribute("currentSort", sort.name());
+        model.addAttribute("selectedSubmission", resolveSelectedSubmission(selected, submissionsPage));
         return "admin/contact-submissions";
     }
 
@@ -47,11 +52,13 @@ public class AdminController {
             @Valid @ModelAttribute UpdateContactSubmissionForm updateForm,
             @RequestParam(defaultValue = "") String query,
             @RequestParam(name = "filterStatus", required = false) ContactSubmissionStatus status,
+            @RequestParam(defaultValue = "NEWEST") AdminSubmissionSort sort,
             @RequestParam(defaultValue = "0") int page,
             RedirectAttributes redirectAttributes) {
         contactService.updateSubmission(submissionId, updateForm);
         redirectAttributes.addFlashAttribute("adminMessage", "Submission updated.");
-        populateRedirectState(redirectAttributes, query, status, page);
+        populateRedirectState(redirectAttributes, query, status, sort, page);
+        redirectAttributes.addAttribute("selected", submissionId);
         return "redirect:/admin/contact-submissions";
     }
 
@@ -60,17 +67,19 @@ public class AdminController {
             @PathVariable long submissionId,
             @RequestParam(defaultValue = "") String query,
             @RequestParam(name = "filterStatus", required = false) ContactSubmissionStatus status,
+            @RequestParam(defaultValue = "NEWEST") AdminSubmissionSort sort,
             @RequestParam(defaultValue = "0") int page,
             RedirectAttributes redirectAttributes) {
         contactService.deleteSubmission(submissionId);
         redirectAttributes.addFlashAttribute("adminMessage", "Submission deleted.");
-        populateRedirectState(redirectAttributes, query, status, page);
+        populateRedirectState(redirectAttributes, query, status, sort, page);
         return "redirect:/admin/contact-submissions";
     }
 
     private void populateRedirectState(RedirectAttributes redirectAttributes,
                                        String query,
                                        ContactSubmissionStatus status,
+                                       AdminSubmissionSort sort,
                                        int page) {
         if (query != null && !query.isBlank()) {
             redirectAttributes.addAttribute("query", query);
@@ -78,6 +87,15 @@ public class AdminController {
         if (status != null) {
             redirectAttributes.addAttribute("status", status);
         }
+        redirectAttributes.addAttribute("sort", sort);
         redirectAttributes.addAttribute("page", Math.max(page, 0));
+    }
+
+    private ContactSubmission resolveSelectedSubmission(Long selectedSubmissionId,
+                                                        Page<ContactSubmission> submissionsPage) {
+        if (selectedSubmissionId != null) {
+            return contactService.findSubmission(selectedSubmissionId).orElse(null);
+        }
+        return submissionsPage.getContent().stream().findFirst().orElse(null);
     }
 }

--- a/src/main/java/com/codernawaki/portfolio/AdminSubmissionSort.java
+++ b/src/main/java/com/codernawaki/portfolio/AdminSubmissionSort.java
@@ -1,0 +1,26 @@
+package com.codernawaki.portfolio;
+
+import org.springframework.data.domain.Sort;
+
+public enum AdminSubmissionSort {
+    NEWEST("Newest first", Sort.by(Sort.Order.desc("createdAt"))),
+    OLDEST("Oldest first", Sort.by(Sort.Order.asc("createdAt"))),
+    NAME("Name A-Z", Sort.by(Sort.Order.asc("name"), Sort.Order.desc("createdAt"))),
+    STATUS("Status", Sort.by(Sort.Order.asc("status"), Sort.Order.desc("createdAt")));
+
+    private final String label;
+    private final Sort sort;
+
+    AdminSubmissionSort(String label, Sort sort) {
+        this.label = label;
+        this.sort = sort;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public Sort toSort() {
+        return sort;
+    }
+}

--- a/src/main/java/com/codernawaki/portfolio/ContactService.java
+++ b/src/main/java/com/codernawaki/portfolio/ContactService.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Optional;
+
 @Service
 public class ContactService {
 
@@ -53,6 +55,10 @@ public class ContactService {
         String normalized = normalizeQuery(query);
         String searchPattern = normalized != null ? "%" + normalized.toLowerCase() + "%" : null;
         return contactSubmissionRepository.search(searchPattern, status, pageable);
+    }
+
+    public Optional<ContactSubmission> findSubmission(long submissionId) {
+        return contactSubmissionRepository.findById(submissionId);
     }
 
     public void updateSubmission(long submissionId, UpdateContactSubmissionForm updateForm) {

--- a/src/main/java/com/codernawaki/portfolio/ContactSubmissionRepository.java
+++ b/src/main/java/com/codernawaki/portfolio/ContactSubmissionRepository.java
@@ -18,7 +18,6 @@ public interface ContactSubmissionRepository extends JpaRepository<ContactSubmis
                    or lower(submission.message) like cast(:query as string)
                    or (submission.adminNote is not null
                        and lower(submission.adminNote) like cast(:query as string)))
-            order by submission.createdAt desc
             """)
     Page<ContactSubmission> search(
             @Param("query") String query,

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -297,6 +297,49 @@ main { padding: 2rem 0 5rem; }
 .admin-table-wrap {
     overflow-x: auto;
 }
+.admin-detail-card {
+    margin-top: 1.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+}
+.admin-detail-header,
+.admin-detail-meta,
+.admin-dialog-content {
+    display: grid;
+    gap: 1rem;
+}
+.admin-detail-grid {
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 1.5rem;
+}
+.admin-detail-panel {
+    padding: 1.25rem;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.72);
+}
+.admin-detail-panel h4 {
+    margin-bottom: 1rem;
+}
+.admin-detail-meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin: 0 0 1rem;
+}
+.admin-detail-meta dt {
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+.admin-detail-meta dd {
+    margin: 0.2rem 0 0;
+}
+.admin-message-body {
+    margin: 0;
+    white-space: pre-wrap;
+    line-height: 1.7;
+}
 .submission-table {
     width: 100%;
     border-collapse: collapse;
@@ -318,6 +361,9 @@ main { padding: 2rem 0 5rem; }
 .note-cell {
     min-width: 15rem;
 }
+.submission-row-selected {
+    background: rgba(184, 80, 46, 0.08);
+}
 .status-pill {
     display: inline-flex;
     padding: 0.35rem 0.8rem;
@@ -327,12 +373,24 @@ main { padding: 2rem 0 5rem; }
     font-size: 0.82rem;
     font-weight: 700;
 }
+.status-pill-new {
+    background: rgba(184, 80, 46, 0.12);
+    color: var(--accent-dark);
+}
+.status-pill-reviewed {
+    background: rgba(43, 108, 176, 0.14);
+    color: #1f4e80;
+}
+.status-pill-replied {
+    background: rgba(42, 122, 87, 0.14);
+    color: #1f6e4e;
+}
 .empty-value {
     color: var(--muted);
     font-style: italic;
 }
 .action-cell {
-    min-width: 18rem;
+    min-width: 10rem;
 }
 .submission-update-form,
 .submission-delete-form {
@@ -341,6 +399,21 @@ main { padding: 2rem 0 5rem; }
 }
 .admin-delete-button {
     color: var(--error);
+}
+.admin-dialog {
+    border: none;
+    border-radius: var(--radius-lg);
+    padding: 0;
+    max-width: 26rem;
+    width: calc(100% - 2rem);
+    box-shadow: var(--shadow);
+}
+.admin-dialog::backdrop {
+    background: rgba(18, 16, 14, 0.45);
+}
+.admin-dialog-content {
+    padding: 1.5rem;
+    background: #fffaf4;
 }
 .admin-pagination {
     margin-top: 1.25rem;
@@ -413,6 +486,10 @@ main { padding: 2rem 0 5rem; }
     .admin-pagination {
         flex-direction: column;
         align-items: stretch;
+    }
+    .admin-detail-grid,
+    .admin-detail-meta {
+        grid-template-columns: 1fr;
     }
     .project-detail-hero,
     .project-detail-grid {

--- a/src/main/resources/templates/admin/contact-submissions.html
+++ b/src/main/resources/templates/admin/contact-submissions.html
@@ -47,6 +47,17 @@
                     </option>
                 </select>
             </label>
+            <label class="admin-filter-field">
+                <span>Sort</span>
+                <select name="sort">
+                    <option th:each="availableSort : ${availableSorts}"
+                            th:value="${availableSort}"
+                            th:text="${availableSort.label}"
+                            th:selected="${currentSort == availableSort.name()}">
+                        Newest first
+                    </option>
+                </select>
+            </label>
             <div class="admin-filter-actions">
                 <button class="button button-primary" type="submit">Apply</button>
                 <a class="button button-secondary" th:href="@{/admin/contact-submissions}">Reset</a>
@@ -65,95 +76,182 @@
                 <tr>
                     <th>Name</th>
                     <th>Email</th>
-                    <th>Message</th>
                     <th>Status</th>
-                    <th>Admin note</th>
                     <th>Received</th>
+                    <th>Preview</th>
                     <th>Action</th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr th:each="submission : ${submissions}">
+                <tr th:each="submission : ${submissions}"
+                    th:classappend="${selectedSubmission != null and selectedSubmission.id == submission.id} ? ' submission-row-selected'">
                     <td th:text="${submission.name}">Lama</td>
                     <td>
                         <a th:href="'mailto:' + ${submission.email}" th:text="${submission.email}">lama@example.com</a>
                     </td>
-                    <td class="message-cell" th:text="${submission.message}">Message body</td>
                     <td>
-                        <span class="status-pill" th:text="${submission.status}">NEW</span>
-                    </td>
-                    <td class="note-cell">
-                        <p th:if="${submission.adminNote}" th:text="${submission.adminNote}">Follow-up note</p>
-                        <span th:unless="${submission.adminNote}" class="empty-value">No note yet</span>
+                        <span class="status-pill"
+                              th:classappend="${submission.status != null ? ' status-pill-' + #strings.toLowerCase(submission.status.name()) : ''}"
+                              th:text="${submission.status != null ? submission.status : 'UNKNOWN'}">NEW</span>
                     </td>
                     <td th:text="${#temporals.format(submission.createdAt, 'yyyy-MM-dd HH:mm')}">2026-04-08 19:30</td>
+                    <td class="message-cell" th:text="${#strings.abbreviate(submission.message, 120)}">Message body</td>
                     <td class="action-cell">
-                        <form class="submission-update-form"
-                              th:action="@{/admin/contact-submissions/{submissionId}(submissionId=${submission.id})}"
-                              method="post">
-                            <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-                            <input type="hidden" name="query" th:value="${currentQuery}">
-                            <input type="hidden" name="filterStatus" th:value="${currentStatus}">
-                            <input type="hidden" name="page" th:value="${submissionsPage.number}">
-                            <label>
-                                <span>Status</span>
-                                <select name="status">
-                                    <option th:each="availableStatus : ${availableStatuses}"
-                                            th:value="${availableStatus}"
-                                            th:text="${availableStatus}"
-                                            th:selected="${availableStatus == submission.status}">
-                                        NEW
-                                    </option>
-                                </select>
-                            </label>
-                            <label>
-                                <span>Note</span>
-                                <textarea name="adminNote"
-                                          rows="4"
-                                          placeholder="Add recruiter follow-up details..."
-                                          th:text="${submission.adminNote}"></textarea>
-                            </label>
-                            <div class="admin-form-actions">
-                                <button class="button button-primary admin-save-button" type="submit">Save</button>
-                            </div>
-                        </form>
-                        <form class="submission-delete-form"
-                              th:action="@{/admin/contact-submissions/{submissionId}/delete(submissionId=${submission.id})}"
-                              method="post">
-                            <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-                            <input type="hidden" name="query" th:value="${currentQuery}">
-                            <input type="hidden" name="filterStatus" th:value="${currentStatus}">
-                            <input type="hidden" name="page" th:value="${submissionsPage.number}">
-                            <button class="button button-secondary admin-delete-button" type="submit">Delete</button>
-                        </form>
+                        <a class="button button-secondary"
+                           th:href="@{/admin/contact-submissions(query=${currentQuery}, status=${currentStatus}, sort=${currentSort}, page=${submissionsPage.number}, selected=${submission.id})}">
+                            View details
+                        </a>
                     </td>
                 </tr>
                 </tbody>
             </table>
         </div>
 
+        <section th:if="${selectedSubmission != null}" class="admin-detail-card">
+            <div class="admin-detail-header">
+                <div>
+                    <p class="eyebrow">Selected submission</p>
+                    <h3 th:text="${selectedSubmission.name}">Lama</h3>
+                </div>
+                <span class="status-pill"
+                      th:classappend="${selectedSubmission.status != null ? ' status-pill-' + #strings.toLowerCase(selectedSubmission.status.name()) : ''}"
+                      th:text="${selectedSubmission.status != null ? selectedSubmission.status : 'UNKNOWN'}">NEW</span>
+            </div>
+
+            <div class="admin-detail-grid">
+                <div class="admin-detail-panel">
+                    <h4>Message</h4>
+                    <dl class="admin-detail-meta">
+                        <div>
+                            <dt>Email</dt>
+                            <dd><a th:href="'mailto:' + ${selectedSubmission.email}" th:text="${selectedSubmission.email}">lama@example.com</a></dd>
+                        </div>
+                        <div>
+                            <dt>Received</dt>
+                            <dd th:text="${#temporals.format(selectedSubmission.createdAt, 'yyyy-MM-dd HH:mm')}">2026-04-08 19:30</dd>
+                        </div>
+                    </dl>
+                    <p class="admin-message-body" th:text="${selectedSubmission.message}">Message body</p>
+                </div>
+
+                <div class="admin-detail-panel">
+                    <h4>Admin follow-up</h4>
+                    <form class="submission-update-form"
+                          th:action="@{/admin/contact-submissions/{submissionId}(submissionId=${selectedSubmission.id})}"
+                          method="post">
+                        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <input type="hidden" name="query" th:value="${currentQuery}">
+                        <input type="hidden" name="filterStatus" th:value="${currentStatus}">
+                        <input type="hidden" name="sort" th:value="${currentSort}">
+                        <input type="hidden" name="page" th:value="${submissionsPage.number}">
+                        <label>
+                            <span>Status</span>
+                            <select name="status">
+                                <option th:each="availableStatus : ${availableStatuses}"
+                                        th:value="${availableStatus}"
+                                        th:text="${availableStatus}"
+                                        th:selected="${availableStatus == selectedSubmission.status}">
+                                    NEW
+                                </option>
+                            </select>
+                        </label>
+                        <label>
+                            <span>Note</span>
+                            <textarea name="adminNote"
+                                      rows="6"
+                                      placeholder="Add recruiter follow-up details..."
+                                      th:text="${selectedSubmission.adminNote}"></textarea>
+                        </label>
+                        <div class="admin-form-actions">
+                            <button class="button button-primary admin-save-button" type="submit">Save changes</button>
+                        </div>
+                    </form>
+
+                    <form class="submission-delete-form"
+                          th:id="'delete-submission-' + ${selectedSubmission.id}"
+                          th:action="@{/admin/contact-submissions/{submissionId}/delete(submissionId=${selectedSubmission.id})}"
+                          method="post">
+                        <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <input type="hidden" name="query" th:value="${currentQuery}">
+                        <input type="hidden" name="filterStatus" th:value="${currentStatus}">
+                        <input type="hidden" name="sort" th:value="${currentSort}">
+                        <input type="hidden" name="page" th:value="${submissionsPage.number}">
+                        <button class="button button-secondary admin-delete-button"
+                                type="button"
+                                th:attr="data-delete-form=${'delete-submission-' + selectedSubmission.id}">
+                            Delete submission
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </section>
+
         <nav th:if="${submissionsPage.totalPages > 1}" class="admin-pagination" aria-label="Submission pages">
             <a class="button button-secondary"
                th:classappend="${submissionsPage.first} ? ' is-disabled'"
                th:href="${submissionsPage.first}
                     ? '#'
-                    : @{/admin/contact-submissions(query=${currentQuery}, status=${currentStatus}, page=${submissionsPage.number - 1})}">Previous</a>
+                    : @{/admin/contact-submissions(query=${currentQuery}, status=${currentStatus}, sort=${currentSort}, page=${submissionsPage.number - 1}, selected=${selectedSubmission != null ? selectedSubmission.id : null})}">Previous</a>
             <div class="admin-page-links">
                 <a th:each="pageNumber : ${#numbers.sequence(0, submissionsPage.totalPages - 1)}"
                    class="admin-page-link"
                    th:classappend="${pageNumber == submissionsPage.number} ? ' is-active'"
-                   th:href="@{/admin/contact-submissions(query=${currentQuery}, status=${currentStatus}, page=${pageNumber})}"
+                   th:href="@{/admin/contact-submissions(query=${currentQuery}, status=${currentStatus}, sort=${currentSort}, page=${pageNumber}, selected=${selectedSubmission != null ? selectedSubmission.id : null})}"
                    th:text="${pageNumber + 1}">1</a>
             </div>
             <a class="button button-secondary"
                th:classappend="${submissionsPage.last} ? ' is-disabled'"
                th:href="${submissionsPage.last}
                     ? '#'
-                    : @{/admin/contact-submissions(query=${currentQuery}, status=${currentStatus}, page=${submissionsPage.number + 1})}">Next</a>
+                    : @{/admin/contact-submissions(query=${currentQuery}, status=${currentStatus}, sort=${currentSort}, page=${submissionsPage.number + 1}, selected=${selectedSubmission != null ? selectedSubmission.id : null})}">Next</a>
         </nav>
     </section>
 </main>
 
+<dialog id="delete-confirm-dialog" class="admin-dialog">
+    <form method="dialog" class="admin-dialog-content">
+        <h3>Delete submission?</h3>
+        <p>This action cannot be undone.</p>
+        <div class="admin-form-actions">
+            <button class="button button-secondary" type="submit">Cancel</button>
+            <button class="button button-primary admin-delete-confirm" type="button">Delete</button>
+        </div>
+    </form>
+</dialog>
+
 <footer th:replace="~{fragments :: footer}"></footer>
+<script>
+    (() => {
+        const dialog = document.getElementById('delete-confirm-dialog');
+        const confirmButton = document.querySelector('.admin-delete-confirm');
+        let formId = null;
+
+        document.querySelectorAll('[data-delete-form]').forEach((button) => {
+            button.addEventListener('click', () => {
+                formId = button.dataset.deleteForm;
+                if (dialog && typeof dialog.showModal === 'function') {
+                    dialog.showModal();
+                    return;
+                }
+                const form = document.getElementById(formId);
+                if (form && window.confirm('Delete this submission?')) {
+                    form.submit();
+                }
+            });
+        });
+
+        if (confirmButton) {
+            confirmButton.addEventListener('click', () => {
+                const form = formId ? document.getElementById(formId) : null;
+                if (dialog) {
+                    dialog.close();
+                }
+                if (form) {
+                    form.submit();
+                }
+            });
+        }
+    })();
+</script>
 </body>
 </html>

--- a/src/test/java/com/codernawaki/portfolio/AdminControllerTest.java
+++ b/src/test/java/com/codernawaki/portfolio/AdminControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,8 +55,8 @@ class AdminControllerTest {
         submission.setStatus(ContactSubmissionStatus.NEW);
         submission.setCreatedAt(Instant.parse("2026-04-08T10:15:00Z"));
 
-        when(contactService.findSubmissions("", null, PageRequest.of(0, 10)))
-                .thenReturn(new PageImpl<>(List.of(submission), PageRequest.of(0, 10), 1));
+        when(contactService.findSubmissions("", null, PageRequest.of(0, 10, AdminSubmissionSort.NEWEST.toSort())))
+                .thenReturn(new PageImpl<>(List.of(submission), PageRequest.of(0, 10, AdminSubmissionSort.NEWEST.toSort()), 1));
 
         mockMvc.perform(get("/admin/contact-submissions"))
                 .andExpect(status().isOk())
@@ -63,22 +64,36 @@ class AdminControllerTest {
                 .andExpect(model().attributeExists("submissions"))
                 .andExpect(model().attributeExists("submissionsPage"))
                 .andExpect(model().attributeExists("availableStatuses"))
+                .andExpect(model().attribute("currentSort", "NEWEST"))
+                .andExpect(model().attributeExists("selectedSubmission"))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("lama@example.com")))
-                .andExpect(content().string(org.hamcrest.Matchers.containsString("I would like to discuss a full stack role.")));
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("View details")));
     }
 
     @Test
     void shouldApplyFiltersWhenRenderingContactSubmissionsPage() throws Exception {
-        when(contactService.findSubmissions("lama", ContactSubmissionStatus.NEW, PageRequest.of(1, 10)))
-                .thenReturn(Page.empty(PageRequest.of(1, 10)));
+        ContactSubmission submission = new ContactSubmission();
+        submission.setName("Lama");
+        submission.setEmail("lama@example.com");
+        submission.setMessage("I would like to discuss a role.");
+        submission.setStatus(ContactSubmissionStatus.NEW);
+        submission.setCreatedAt(Instant.parse("2026-04-08T10:15:00Z"));
+        when(contactService.findSubmissions("lama", ContactSubmissionStatus.NEW,
+                PageRequest.of(1, 10, AdminSubmissionSort.OLDEST.toSort())))
+                .thenReturn(new PageImpl<>(List.of(submission), PageRequest.of(1, 10, AdminSubmissionSort.OLDEST.toSort()), 1));
+        when(contactService.findSubmission(9L)).thenReturn(Optional.of(submission));
 
         mockMvc.perform(get("/admin/contact-submissions")
                         .param("query", "lama")
                         .param("status", "NEW")
+                        .param("sort", "OLDEST")
+                        .param("selected", "9")
                         .param("page", "1"))
                 .andExpect(status().isOk())
                 .andExpect(model().attribute("currentQuery", "lama"))
-                .andExpect(model().attribute("currentStatus", "NEW"));
+                .andExpect(model().attribute("currentStatus", "NEW"))
+                .andExpect(model().attribute("currentSort", "OLDEST"))
+                .andExpect(model().attributeExists("selectedSubmission"));
     }
 
     @Test
@@ -88,9 +103,10 @@ class AdminControllerTest {
                         .param("adminNote", "Follow up this week.")
                         .param("query", "lama")
                         .param("filterStatus", "NEW")
+                        .param("sort", "STATUS")
                         .param("page", "1"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/admin/contact-submissions?query=lama&status=NEW&page=1"))
+                .andExpect(redirectedUrl("/admin/contact-submissions?query=lama&status=NEW&sort=STATUS&page=1&selected=7"))
                 .andExpect(flash().attribute("adminMessage", "Submission updated."));
 
         verify(contactService).updateSubmission(org.mockito.ArgumentMatchers.eq(7L),
@@ -103,9 +119,10 @@ class AdminControllerTest {
         mockMvc.perform(post("/admin/contact-submissions/7/delete")
                         .param("query", "lama")
                         .param("filterStatus", "REVIEWED")
+                        .param("sort", "NAME")
                         .param("page", "0"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/admin/contact-submissions?query=lama&status=REVIEWED&page=0"))
+                .andExpect(redirectedUrl("/admin/contact-submissions?query=lama&status=REVIEWED&sort=NAME&page=0"))
                 .andExpect(flash().attribute("adminMessage", "Submission deleted."));
 
         verify(contactService).deleteSubmission(7L);

--- a/src/test/java/com/codernawaki/portfolio/ContactServiceTest.java
+++ b/src/test/java/com/codernawaki/portfolio/ContactServiceTest.java
@@ -64,7 +64,7 @@ class ContactServiceTest {
 
     @Test
     void shouldNormalizeQueryAndCallSearch() {
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, 10, AdminSubmissionSort.NEWEST.toSort());
         when(contactSubmissionRepository.search(eq("%test%"), eq(ContactSubmissionStatus.NEW), eq(pageable)))
                 .thenReturn(Page.empty());
 
@@ -75,7 +75,7 @@ class ContactServiceTest {
 
     @Test
     void shouldHandleNullQueryInSearch() {
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, 10, AdminSubmissionSort.NEWEST.toSort());
         when(contactSubmissionRepository.search(eq(null), eq(null), eq(pageable)))
                 .thenReturn(Page.empty());
 


### PR DESCRIPTION
## Summary

  This PR improves the admin contact submission experience by separating inbox scanning from submission editing, adding sorting controls, and making
  status and delete actions clearer.

  ## What Changed

  - Added admin-side sort options for contact submissions:
      - newest first
      - oldest first
      - name A-Z
      - status
  - Added selected-submission state so the admin page can keep focus on one submission while filtering and paging
  - Reworked the admin UI into:
      - a lighter inbox table for quick scanning
      - a dedicated detail panel for full message review and follow-up actions
  - Moved update and delete actions out of dense table rows into the detail view
  - Added a delete confirmation dialog before submission removal
  - Added clearer status pill styling for NEW, REVIEWED, and REPLIED
  - Removed hardcoded repository ordering so pageable sorting from the controller is applied correctly
  - Added test coverage for the new sort and selection behavior

  ## Why

  The previous admin page handled everything inline in the table, which made the screen dense and harder to use as the number of submissions grew. This
  change makes the page behave more like a real inbox:

  - scan quickly
  - open one submission
  - update status and notes in context
  - avoid accidental deletion

  ## Implementation Notes

  - Added AdminSubmissionSort to centralize admin sort behavior
  - AdminController now preserves:
      - query
      - status filter
      - sort
      - page
      - selected submission
  - ContactSubmissionRepository no longer forces createdAt desc in the query, which allows pageable sort options to work
  - The template now renders defensively if a submission object is incomplete in test-only scenarios