### PR TITLE
Add integration coverage for contact submission flows

### DIFF
--- a/src/test/java/com/codernawaki/portfolio/ContactSubmissionFlowIntegrationTest.java
+++ b/src/test/java/com/codernawaki/portfolio/ContactSubmissionFlowIntegrationTest.java
@@ -1,0 +1,85 @@
+package com.codernawaki.portfolio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest(properties = {
+        "PORTFOLIO_ADMIN_USERNAME=test-admin",
+        "PORTFOLIO_ADMIN_PASSWORD=test-password",
+        "SPRING_MAIL_USERNAME=",
+        "SPRING_MAIL_PASSWORD=",
+        "PORTFOLIO_CONTACT_NOTIFICATION_EMAIL="
+})
+class ContactSubmissionFlowIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private ContactSubmissionRepository contactSubmissionRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        contactSubmissionRepository.deleteAll();
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .build();
+    }
+
+    @Test
+    void shouldPersistSubmissionThroughPublicContactEndpoint() throws Exception {
+        mockMvc.perform(post("/submitContactForm")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "  Lama Nawaraj  ",
+                                  "email": "  lama@example.com  ",
+                                  "message": "  Interested in discussing a full stack role.  "
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.fieldErrors").isEmpty());
+
+        assertThat(contactSubmissionRepository.count()).isEqualTo(1);
+        ContactSubmission savedSubmission = contactSubmissionRepository.findAll().get(0);
+        assertThat(savedSubmission.getName()).isEqualTo("Lama Nawaraj");
+        assertThat(savedSubmission.getEmail()).isEqualTo("lama@example.com");
+        assertThat(savedSubmission.getMessage()).isEqualTo("Interested in discussing a full stack role.");
+        assertThat(savedSubmission.getStatus()).isEqualTo(ContactSubmissionStatus.NEW);
+        assertThat(savedSubmission.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    void shouldRejectInvalidSubmissionWithoutPersistingAnything() throws Exception {
+        mockMvc.perform(post("/submitContactForm")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "",
+                                  "email": "wrong-email",
+                                  "message": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.fieldErrors.name").value("Please enter your name."))
+                .andExpect(jsonPath("$.fieldErrors.email").value("Please enter a valid email address."))
+                .andExpect(jsonPath("$.fieldErrors.message").value("Please enter a message."));
+
+        assertThat(contactSubmissionRepository.count()).isZero();
+    }
+}

--- a/src/test/java/com/codernawaki/portfolio/ContactSubmissionRepositoryIntegrationTest.java
+++ b/src/test/java/com/codernawaki/portfolio/ContactSubmissionRepositoryIntegrationTest.java
@@ -1,0 +1,153 @@
+package com.codernawaki.portfolio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@SpringBootTest(properties = {
+        "PORTFOLIO_ADMIN_USERNAME=test-admin",
+        "PORTFOLIO_ADMIN_PASSWORD=test-password"
+})
+class ContactSubmissionRepositoryIntegrationTest {
+
+    @Autowired
+    private ContactSubmissionRepository contactSubmissionRepository;
+
+    @BeforeEach
+    void setUp() {
+        contactSubmissionRepository.deleteAll();
+    }
+
+    @Test
+    void shouldSearchAcrossAdminNoteWithStatusFilter() {
+        ContactSubmission matchingSubmission = submission(
+                "Lama",
+                "lama@example.com",
+                "Interested in a backend role.",
+                "Send interview slots.",
+                ContactSubmissionStatus.REVIEWED,
+                Instant.parse("2026-04-20T10:00:00Z"));
+        ContactSubmission wrongStatus = submission(
+                "Lama",
+                "lama@example.com",
+                "Interested in a backend role.",
+                "Send interview slots.",
+                ContactSubmissionStatus.NEW,
+                Instant.parse("2026-04-20T11:00:00Z"));
+        ContactSubmission noMatch = submission(
+                "Another Candidate",
+                "another@example.com",
+                "Question about the stack.",
+                "Asked for architecture notes.",
+                ContactSubmissionStatus.REVIEWED,
+                Instant.parse("2026-04-20T12:00:00Z"));
+
+        contactSubmissionRepository.saveAll(List.of(matchingSubmission, wrongStatus, noMatch));
+
+        Page<ContactSubmission> result = contactSubmissionRepository.search(
+                "%interview%",
+                ContactSubmissionStatus.REVIEWED,
+                PageRequest.of(0, 10, AdminSubmissionSort.NEWEST.toSort()));
+
+        assertThat(result.getContent())
+                .extracting(ContactSubmission::getEmail)
+                .containsExactly("lama@example.com");
+    }
+
+    @Test
+    void shouldApplyRequestedSortFromPageable() {
+        ContactSubmission zed = submission(
+                "Zed",
+                "zed@example.com",
+                "First message.",
+                null,
+                ContactSubmissionStatus.NEW,
+                Instant.parse("2026-04-20T10:00:00Z"));
+        ContactSubmission anna = submission(
+                "Anna",
+                "anna@example.com",
+                "Second message.",
+                null,
+                ContactSubmissionStatus.NEW,
+                Instant.parse("2026-04-20T11:00:00Z"));
+        ContactSubmission mike = submission(
+                "Mike",
+                "mike@example.com",
+                "Third message.",
+                null,
+                ContactSubmissionStatus.NEW,
+                Instant.parse("2026-04-20T12:00:00Z"));
+
+        contactSubmissionRepository.saveAll(List.of(zed, anna, mike));
+
+        Page<ContactSubmission> result = contactSubmissionRepository.search(
+                null,
+                null,
+                PageRequest.of(0, 10, AdminSubmissionSort.NAME.toSort()));
+
+        assertThat(result.getContent())
+                .extracting(ContactSubmission::getName)
+                .containsExactly("Anna", "Mike", "Zed");
+    }
+
+    @Test
+    void shouldApplyRequestedPagingAndOldestSort() {
+        ContactSubmission first = submission(
+                "First",
+                "first@example.com",
+                "First message.",
+                null,
+                ContactSubmissionStatus.NEW,
+                Instant.parse("2026-04-20T10:00:00Z"));
+        ContactSubmission second = submission(
+                "Second",
+                "second@example.com",
+                "Second message.",
+                null,
+                ContactSubmissionStatus.NEW,
+                Instant.parse("2026-04-20T11:00:00Z"));
+        ContactSubmission third = submission(
+                "Third",
+                "third@example.com",
+                "Third message.",
+                null,
+                ContactSubmissionStatus.NEW,
+                Instant.parse("2026-04-20T12:00:00Z"));
+
+        contactSubmissionRepository.saveAll(List.of(first, second, third));
+
+        Page<ContactSubmission> result = contactSubmissionRepository.search(
+                null,
+                null,
+                PageRequest.of(1, 1, AdminSubmissionSort.OLDEST.toSort()));
+
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getContent())
+                .extracting(ContactSubmission::getName)
+                .containsExactly("Second");
+    }
+
+    private ContactSubmission submission(String name,
+                                         String email,
+                                         String message,
+                                         String adminNote,
+                                         ContactSubmissionStatus status,
+                                         Instant createdAt) {
+        ContactSubmission submission = new ContactSubmission();
+        submission.setName(name);
+        submission.setEmail(email);
+        submission.setMessage(message);
+        submission.setAdminNote(adminNote);
+        submission.setStatus(status);
+        submission.setCreatedAt(createdAt);
+        return submission;
+    }
+}


### PR DESCRIPTION
-basically added integration test for contact submission

  - repository search matches adminNote and respects status filters
  - pageable sorting and paging are actually applied by the repository query
  - /submitContactForm persists a real submission through the full Spring stack
  - invalid submissions return validation errors and do not persist anything
