### PR TITLE
This PR adds a Docker Desktop Kubernetes overlay so the portfolio app can be run locally on a Kubernetes cluster without Minikube.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,21 @@ kubectl apply -k devops/minikube
 minikube service -n portfolio portfolio-app --url
 ```
 
+If you use Docker Desktop Kubernetes instead, use the Docker Desktop overlay:
+
+```bash
+docker build -t portfolio:docker-desktop .
+kubectl apply -k devops/docker-desktop
+kubectl -n portfolio get pods
+kubectl -n portfolio get svc portfolio-app
+```
+
+Open the app at `http://localhost:30081`, or use port-forwarding if your setup does not expose NodePorts on localhost:
+
+```bash
+kubectl -n portfolio port-forward svc/portfolio-app 8081:80
+```
+
 Tracing:
 
 - The application exports traces via OTLP to Tempo

--- a/devops/README.md
+++ b/devops/README.md
@@ -35,3 +35,22 @@ minikube service -n portfolio portfolio-app --url
 ```
 
 The Minikube overlay runs the app on a local `NodePort` and points `PORTFOLIO_SITE_URL` at `http://localhost:30080` so the generated metadata matches the cluster URL more closely.
+
+## Docker Desktop Kubernetes
+
+If you already use Docker Desktop, use the Docker Desktop overlay instead of Minikube:
+
+```bash
+docker build -t portfolio:docker-desktop .
+kubectl apply -k devops/docker-desktop
+kubectl -n portfolio get pods
+kubectl -n portfolio get svc portfolio-app
+```
+
+Open the app at `http://localhost:30081`.
+
+If the NodePort is not reachable in your Docker Desktop setup, use port-forwarding as a fallback:
+
+```bash
+kubectl -n portfolio port-forward svc/portfolio-app 8081:80
+```

--- a/devops/docker-desktop/app-deployment-patch.yaml
+++ b/devops/docker-desktop/app-deployment-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: portfolio-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: portfolio-app
+          imagePullPolicy: IfNotPresent

--- a/devops/docker-desktop/app-hpa-delete.yaml
+++ b/devops/docker-desktop/app-hpa-delete.yaml
@@ -1,0 +1,5 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: portfolio-app
+$patch: delete

--- a/devops/docker-desktop/app-ingress-delete.yaml
+++ b/devops/docker-desktop/app-ingress-delete.yaml
@@ -1,0 +1,5 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: portfolio-app
+$patch: delete

--- a/devops/docker-desktop/app-service-patch.yaml
+++ b/devops/docker-desktop/app-service-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: portfolio-app
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8081
+      nodePort: 30081

--- a/devops/docker-desktop/configmap-patch.yaml
+++ b/devops/docker-desktop/configmap-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portfolio-config
+data:
+  SPRING_PROFILES_ACTIVE: prod
+  PORTFOLIO_SITE_URL: http://localhost:30081
+  MANAGEMENT_OPENTELEMETRY_TRACING_EXPORT_OTLP_ENDPOINT: http://localhost:4318/v1/traces

--- a/devops/docker-desktop/kustomization.yaml
+++ b/devops/docker-desktop/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../kubernetes
+
+images:
+  - name: ghcr.io/codernawaki/portfolio
+    newName: portfolio
+    newTag: docker-desktop
+
+patches:
+  - path: app-service-patch.yaml
+  - path: app-deployment-patch.yaml
+  - path: configmap-patch.yaml
+  - path: app-ingress-delete.yaml
+  - path: app-hpa-delete.yaml


### PR DESCRIPTION
## What changed

  - Added devops/docker-desktop/ as a dedicated Kustomize overlay.
  - Reused the base Kubernetes manifests from devops/kubernetes/.
  - Patched the app service to use NodePort 30081 for local access.
  - Patched the app deployment to use the local image tag portfolio:docker-desktop.
  - Patched PORTFOLIO_SITE_URL to match the local Docker Desktop URL.
  - Removed cluster-only resources like Ingress and HPA from the local overlay.
  - Updated devops/README.md and the root README.md with Docker Desktop Kubernetes instructions.

  ## Validation

  - Verified the overlay renders successfully with kubectl kustomize devops/docker-desktop.

  ## Notes

  - The base Kubernetes manifests remain unchanged.
  - The Docker Desktop overlay is meant for local development and validation.
  - The existing Minikube overlay is still available as an alternative local-cluster path.
