### PR TITLE
Fix Spring Security Authorization Bypass (CVE-2026-22754)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.flywaydb:flyway-database-postgresql'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'tools.jackson.core:jackson-core:3.1.1'
+	implementation 'org.springframework.security:spring-security-config:7.0.5'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'com.bucket4j:bucket4j_jdk17-core:8.12.1'

--- a/docs/issues/issue-spring-security.md
+++ b/docs/issues/issue-spring-security.md
@@ -1,0 +1,20 @@
+Title: Spring Security fails to include path in path matching of xml auth rules
+Repository: CoderNawaki/Portfolio
+---
+### 🛡️ Vulnerability Report
+**Severity:** Critical / High
+**Dependency:** [ spring-security-config ]
+**CVE:** [ CVE-2026-22754]
+
+### 📝 Description
+Vulnerability in Spring Spring Security. If an application uses <sec:intercept-url servlet-path="/servlet-path" pattern="/endpoint/**"/> to define the servlet path for computing a path matcher, then the servlet path is not included and the related authorization rules are not exercised. This can lead to an authorization bypass. This issue affects Spring Security: from 7.0.0 through 7.0.4.
+
+### 🛠️ Fix Plan
+1. [x] Identify latest stable version
+2. [x] Update `build.gradle`
+3. [x] Run local tests to ensure no regressions
+4. [x] Verify dependency tree
+
+### ✅ Acceptance Criteria
+- [x] Vulnerability no longer shows in dependency scan
+- [x] Application builds and starts successfully

--- a/docs/issues/issue-template.md
+++ b/docs/issues/issue-template.md
@@ -1,0 +1,20 @@
+Title: [Brief Title]
+Repository: CoderNawaki/Portfolio
+---
+### 🛡️ Vulnerability Report
+**Severity:** Critical / High
+**Dependency:** [e.g. logback-core]
+**CVE:** [e.g. CVE-2024-XXXX]
+
+### 📝 Description
+Describe the security vulnerability reported by GitHub here.
+
+### 🛠️ Fix Plan
+1. [ ] Identify latest stable version
+2. [ ] Update `build.gradle`
+3. [ ] Run local tests to ensure no regressions
+4. [ ] Verify dependency tree
+
+### ✅ Acceptance Criteria
+- [ ] Vulnerability no longer shows in dependency scan
+- [ ] Application builds and starts successfully


### PR DESCRIPTION
Title: Spring Security fails to include path in path matching of xml auth rules
Repository: CoderNawaki/Portfolio
---
### 🛡️ Vulnerability Report
**Severity:** Critical / High
**Dependency:** [ spring-security-config ]
**CVE:** [ CVE-2026-22754]

### 📝 Description
Vulnerability in Spring Spring Security. If an application uses <sec:intercept-url servlet-path="/servlet-path" pattern="/endpoint/**"/> to define the servlet path for computing a path matcher, then the servlet path is not included and the related authorization rules are not exercised. This can lead to an authorization bypass. This issue affects Spring Security: from 7.0.0 through 7.0.4.

### 🛠️ Fix Plan
1. [x] Identify latest stable version
2. [x] Update `build.gradle`
3. [x] Run local tests to ensure no regressions
4. [x] Verify dependency tree

### ✅ Acceptance Criteria
- [x] Vulnerability no longer shows in dependency scan
- [x] Application builds and starts successfully
