### PR TITLE
Fix Thymeleaf SSTI Vulnerability (CVE-2025-30310)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'tools.jackson.core:jackson-core:3.1.1'
 	implementation 'org.springframework.security:spring-security-config:7.0.5'
+	implementation 'org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE'
+	implementation 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'com.bucket4j:bucket4j_jdk17-core:8.12.1'

--- a/docs/issues/issue-thymeleaf-ssti.md
+++ b/docs/issues/issue-thymeleaf-ssti.md
@@ -1,0 +1,21 @@
+Title: Thymeleaf Server-Side Template Injection (SSTI) in expression execution
+Repository: CoderNawaki/Portfolio
+---
+### 🛡️ Vulnerability Report
+**Severity:** Critical
+**Dependency:** [ thymeleaf ]
+**CVE:** [ CVE-2025-30310 ]
+
+### 📝 Description
+A security bypass vulnerability exists in the expression execution mechanisms of Thymeleaf up to and including 3.1.4.RELEASE. The library fails to properly neutralize specific constructs that allow dangerous expressions to be executed in sandboxed contexts. If an application developer passes unsanitized variables containing such expressions to the template engine, it can result in Server-Side Template Injection (SSTI).
+
+### 🛠️ Fix Plan
+1. [x] Update Thymeleaf version to `3.1.5.RELEASE`
+2. [x] Update `build.gradle` to enforce the secure version
+3. [x] Run local tests to ensure no regressions
+4. [x] Verify dependency tree
+
+### ✅ Acceptance Criteria
+- [x] Vulnerability no longer shows in dependency scan
+- [x] Application builds and starts successfully
+- [x] Templates render correctly


### PR DESCRIPTION
Title: Thymeleaf Server-Side Template Injection (SSTI) in expression execution
Repository: CoderNawaki/Portfolio
---
### 🛡️ Vulnerability Report
**Severity:** Critical
**Dependency:** [ thymeleaf ]
**CVE:** [ CVE-2025-30310 ]

### 📝 Description
A security bypass vulnerability exists in the expression execution mechanisms of Thymeleaf up to and including 3.1.4.RELEASE. The library fails to properly neutralize specific constructs that allow dangerous expressions to be executed in sandboxed contexts. If an application developer passes unsanitized variables containing such expressions to the template engine, it can result in Server-Side Template Injection (SSTI).

### 🛠️ Fix Plan
1. [x] Update Thymeleaf version to `3.1.5.RELEASE`
2. [x] Update `build.gradle` to enforce the secure version
3. [x] Run local tests to ensure no regressions
4. [x] Verify dependency tree

### ✅ Acceptance Criteria
- [x] Vulnerability no longer shows in dependency scan
- [x] Application builds and starts successfully
- [x] Templates render correctly
