### PR TITLE
Fix Apache Commons Lang3 Uncontrolled Recursion Vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	implementation 'org.apache.tomcat.embed:tomcat-embed-core:11.0.21'
 	implementation 'org.apache.tomcat.embed:tomcat-embed-el:11.0.21'
 	implementation 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.21'
+	implementation 'org.apache.commons:commons-lang3:3.19.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'com.bucket4j:bucket4j_jdk17-core:8.12.1'

--- a/docs/issues/issue-commons-lang3-recursion.md
+++ b/docs/issues/issue-commons-lang3-recursion.md
@@ -1,0 +1,20 @@
+Title: Apache Commons Lang3: Uncontrolled Recursion (StackOverflowError) in ClassUtils
+Repository: CoderNawaki/Portfolio
+---
+### 🛡️ Vulnerability Report
+**Severity:** High
+**Dependency:** [ org.apache.commons:commons-lang3 ]
+**Vulnerability:** Uncontrolled Recursion (StackOverflowError)
+
+### 📝 Description
+Uncontrolled Recursion vulnerability in Apache Commons Lang. The methods `ClassUtils.getClass(...)` can throw `StackOverflowError` on very long inputs. This can cause an application to stop. This issue affects versions from 3.0 before 3.18.0.
+
+### 🛠️ Fix Plan
+1. [x] Update `commons-lang3` version to `3.18.0` or higher (3.19.0 recommended).
+2. [x] Update `build.gradle` to enforce the secure version.
+3. [x] Run local tests to ensure no regressions.
+4. [x] Verify dependency tree.
+
+### ✅ Acceptance Criteria
+- [x] `commons-lang3` version is 3.18.0 or higher.
+- [x] Application builds and starts successfully.


### PR DESCRIPTION
Title: Apache Commons Lang3: Uncontrolled Recursion (StackOverflowError) in ClassUtils
Repository: CoderNawaki/Portfolio
---
### 🛡️ Vulnerability Report
**Severity:** High
**Dependency:** [ org.apache.commons:commons-lang3 ]
**Vulnerability:** Uncontrolled Recursion (StackOverflowError)

### 📝 Description
Uncontrolled Recursion vulnerability in Apache Commons Lang. The methods `ClassUtils.getClass(...)` can throw `StackOverflowError` on very long inputs. This can cause an application to stop. This issue affects versions from 3.0 before 3.18.0.

### 🛠️ Fix Plan
1. [x] Update `commons-lang3` version to `3.18.0` or higher (3.19.0 recommended).
2. [x] Update `build.gradle` to enforce the secure version.
3. [x] Run local tests to ensure no regressions.
4. [x] Verify dependency tree.

### ✅ Acceptance Criteria
- [x] `commons-lang3` version is 3.18.0 or higher.
- [x] Application builds and starts successfully.
