### PR TITLE
security: fix SCRAM-SHA-256 DoS in pgjdbc by upgrading to 42.7.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 	implementation 'com.bucket4j:bucket4j_jdk17-lettuce:8.12.1'
 	implementation 'javax.cache:cache-api:1.1.1'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'org.postgresql:postgresql:42.7.11'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/docs/issues/issue-pgjdbc-scram-dos.md
+++ b/docs/issues/issue-pgjdbc-scram-dos.md
@@ -1,0 +1,17 @@
+Title: Security Vulnerability: PostgreSQL JDBC Driver (pgjdbc) - SCRAM-SHA-256 DoS
+Repository: CoderNawaki/Portfolio
+---
+## Description
+The PostgreSQL JDBC driver (pgjdbc) is vulnerable to a client-side Denial of Service (DoS) during SCRAM-SHA-256 authentication. A malicious server can send a very large iteration count in the SCRAM `server-first-message`, causing the client to consume excessive CPU resources during PBKDF2 computation.
+
+## Vulnerability Details
+- **Impact:** High (Denial of Service)
+- **Affected Versions in Project:** `org.postgresql:postgresql:42.7.10`
+- **Fixed Version:** `42.7.11`
+
+## Action Plan
+1. [ ] Create GitHub issue using `scripts/manage-issue.py`.
+2. [ ] Update `build.gradle` to explicitly use `org.postgresql:postgresql:42.7.11`.
+3. [ ] Verify the dependency resolution using `./gradlew dependencies`.
+4. [ ] Run tests to ensure no regressions.
+5. [ ] Create Pull Request linked to the issue.


### PR DESCRIPTION
Fixes #55. Upgrades PostgreSQL JDBC driver to 42.7.11 to address the SCRAM-SHA-256 DoS vulnerability.