### PR TITLE
security: upgrade Spring Boot to 4.0.6 to fix CVE-2026-40972 and CVE-2026-40976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.5'
+	id 'org.springframework.boot' version '4.0.6'
 	id 'io.spring.dependency-management' version '1.1.4'
 }
 

--- a/docs/issues/issue-spring-boot-devtools-timing.md
+++ b/docs/issues/issue-spring-boot-devtools-timing.md
@@ -1,0 +1,20 @@
+Title: Security Vulnerability: Spring Boot DevTools Remote Secret Timing Attack (CVE-2026-40972)
+Repository: CoderNawaki/Portfolio
+---
+## Description
+Spring Boot DevTools remote secret comparison is vulnerable to timing attacks. An attacker on the same network as the remote application can utilize a timing attack to discover the remote secret. This could result in the attacker determining the secret and uploading changed classes, achieving remote code execution (RCE).
+
+Additionally, this upgrade addresses **CVE-2026-40976** (Authorization Bypass in Actuator) which was previously partially mitigated with a manual configuration change.
+
+## Vulnerability Details
+- **Advisory ID:** CVE-2026-40972
+- **Severity:** High (RCE potential)
+- **Impact:** Remote Code Execution via DevTools secret recovery.
+- **Fixed Version:** `4.0.6`
+
+## Action Plan
+1. [ ] Create GitHub issue using `scripts/manage-issue.py`.
+2. [ ] Upgrade Spring Boot from `4.0.5` to `4.0.6` in `build.gradle`.
+3. [ ] Verify the dependency resolution using `./gradlew dependencies`.
+4. [ ] Run tests to ensure no regressions.
+5. [ ] Create Pull Request linked to the issue.


### PR DESCRIPTION
Fixes #59. Upgrades Spring Boot to 4.0.6 to address the DevTools timing attack (CVE-2026-40972) and the Actuator authorization bypass (CVE-2026-40976).