### PR TITLE
Add Terraform as IoC (manage docker-compose)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to .env and fill secrets. Do NOT commit .env
+# Example environment variables used by docker-compose for local runs
+
+# Application admin
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin_change_me
+
+# Grafana (if used)
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin_change_me
+
+# Database
+DB_USER=appuser
+DB_PASSWORD=db_change_me
+DB_NAME=appdb
+
+# Other notes:
+# - Keep strong, unique passwords for ADMIN_PASSWORD and DB_PASSWORD.
+# - Use Docker secrets or a secrets manager for production.
+# - To run locally: cp .env.example .env && docker compose up -d

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ plan.md
 /infra/terraform/terraform.tfstate.backup
 /infra/terraform/.terraform/
 *.tfstate
+
+# Local env
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ out/
 
 ### Local planning ###
 plan.md
+
+# Terraform
+/infra/terraform/terraform.tfstate
+/infra/terraform/terraform.tfstate.backup
+/infra/terraform/.terraform/
+*.tfstate

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.3.0"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,24 @@
+Terraform to manage local docker-compose deployment
+
+This Terraform configuration uses a null_resource with local-exec provisioners to run docker compose for this repository's docker-compose.yml.
+
+Usage
+
+1. Install Terraform (>= 1.0)
+2. From repo root, run:
+
+   cd infra/terraform
+   terraform init
+   terraform apply
+
+This will run: docker compose -f <repo-root>/docker-compose.yml pull && docker compose -f <repo-root>/docker-compose.yml up -d
+
+To tear down the compose stack:
+
+   terraform destroy
+
+Notes
+
+- Terraform uses local-exec; it requires Docker and Docker Compose available on the machine running Terraform.
+- State is stored locally by default. For collaboration, configure a remote backend (e.g., S3, Terraform Cloud).
+- This is intentionally minimal (learning resource). Future iterations can use the Docker provider or Kubernetes provider as needed.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -9,12 +9,13 @@ resource "null_resource" "deploy" {
   }
 
   provisioner "local-exec" {
-    # pull images then start compose in repo root
-    command = "docker compose -f \"${path.module}/../../docker-compose.yml\" pull && docker compose -f \"${path.module}/../../docker-compose.yml\" up -d"
+    working_dir = "${path.module}/../.."
+    command     = "docker compose pull && docker compose up -d"
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
-    command = "docker compose -f \"${path.module}/../../docker-compose.yml\" down"
+    when        = destroy
+    working_dir = "${path.module}/../.."
+    command     = "docker compose down"
   }
 }

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+resource "null_resource" "deploy" {
+  # change triggers to force re-run when apply is called
+  triggers = {
+    always_run = timestamp()
+  }
+
+  provisioner "local-exec" {
+    # pull images then start compose in repo root
+    command = "docker compose -f \"${path.module}/../../docker-compose.yml\" pull && docker compose -f \"${path.module}/../../docker-compose.yml\" up -d"
+  }
+
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "docker compose -f \"${path.module}/../../docker-compose.yml\" down"
+  }
+}


### PR DESCRIPTION
Implements #64: adds infra/terraform to manage docker-compose via Terraform null_resource local-exec. See infra/terraform/README.md for usage. Closes #64.