### PR TITLE
Sprint 2 (#67): Public blog pages, navigation, and homepage integration

### DIFF
--- a/src/main/java/com/codernawaki/portfolio/BlogController.java
+++ b/src/main/java/com/codernawaki/portfolio/BlogController.java
@@ -1,0 +1,54 @@
+package com.codernawaki.portfolio;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+@Controller
+public class BlogController {
+
+    private static final int ARTICLES_PER_PAGE = 10;
+
+    private final BlogService blogService;
+    private final PortfolioService portfolioService;
+
+    public BlogController(BlogService blogService, PortfolioService portfolioService) {
+        this.blogService = blogService;
+        this.portfolioService = portfolioService;
+    }
+
+    @GetMapping("/blog")
+    public String blogList(
+            @RequestParam(defaultValue = "0") int page,
+            Model model) {
+        PortfolioProperties props = portfolioService.getProperties();
+        var articlesPage = blogService.getPublishedArticles(PageRequest.of(page, ARTICLES_PER_PAGE));
+
+        model.addAttribute("articlesPage", articlesPage);
+        model.addAttribute("articles", articlesPage.getContent());
+        model.addAttribute("pageTitle", "Blog | " + props.getDisplayName());
+        model.addAttribute("pageDescription", "Articles and case studies from a full stack developer in Japan.");
+        model.addAttribute("pageUrl", props.getSiteUrl() + "/blog");
+        return "blog/list";
+    }
+
+    @GetMapping("/blog/{slug}")
+    public String blogDetail(@PathVariable String slug, Model model) {
+        PortfolioProperties props = portfolioService.getProperties();
+        Article article = blogService.findBySlug(slug)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Article not found."));
+
+        model.addAttribute("article", article);
+        model.addAttribute("htmlContent", blogService.renderHtml(article.getContent()));
+        model.addAttribute("pageTitle", article.getTitle() + " | Blog | " + props.getDisplayName());
+        model.addAttribute("pageDescription",
+                article.getExcerpt() != null ? article.getExcerpt() : article.getTitle());
+        model.addAttribute("pageUrl", props.getSiteUrl() + "/blog/" + article.getSlug());
+        return "blog/detail";
+    }
+}

--- a/src/main/java/com/codernawaki/portfolio/BlogService.java
+++ b/src/main/java/com/codernawaki/portfolio/BlogService.java
@@ -1,6 +1,7 @@
 package com.codernawaki.portfolio;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -38,6 +39,11 @@ public class BlogService {
                 pageable.getPageSize(),
                 PUBLISHED_SORT);
         return articleRepository.findByStatus(ArticleStatus.PUBLISHED, sorted);
+    }
+
+    public List<Article> getLatestPublishedArticles(int count) {
+        Pageable limit = PageRequest.of(0, count, PUBLISHED_SORT);
+        return articleRepository.findByStatus(ArticleStatus.PUBLISHED, limit).getContent();
     }
 
     public Page<Article> getAllArticles(Pageable pageable) {

--- a/src/main/java/com/codernawaki/portfolio/HomeController.java
+++ b/src/main/java/com/codernawaki/portfolio/HomeController.java
@@ -1,5 +1,7 @@
 package com.codernawaki.portfolio;
 
+import java.util.List;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -12,9 +14,11 @@ import org.springframework.http.HttpStatus;
 public class HomeController {
 
     private final PortfolioService portfolioService;
+    private final BlogService blogService;
 
-    public HomeController(PortfolioService portfolioService) {
+    public HomeController(PortfolioService portfolioService, BlogService blogService) {
         this.portfolioService = portfolioService;
+        this.blogService = blogService;
     }
 
     @GetMapping("/")
@@ -29,6 +33,8 @@ public class HomeController {
         model.addAttribute("proofPoints", props.getProofPoints());
         model.addAttribute("bio", props.getBio());
         model.addAttribute("projects", portfolioService.getFeaturedProjects());
+        List<Article> latestPosts = blogService.getLatestPublishedArticles(3);
+        model.addAttribute("latestPosts", latestPosts);
         model.addAttribute("pageTitle", props.getDisplayName() + " | Full Stack Developer Portfolio");
         model.addAttribute("pageDescription",
                 "Portfolio of Lama Nawaraj, a Java-first full stack developer in Japan covering Spring Boot, frontend delivery, testing, and recruiter-ready project case studies.");
@@ -69,6 +75,10 @@ public class HomeController {
         xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">");
         appendSitemapUrl(xml, baseUrl + "/");
         appendSitemapUrl(xml, baseUrl + "/login");
+        appendSitemapUrl(xml, baseUrl + "/blog");
+        for (Article article : blogService.getLatestPublishedArticles(50)) {
+            appendSitemapUrl(xml, baseUrl + "/blog/" + article.getSlug());
+        }
         for (FeaturedProject project : portfolioService.getFeaturedProjects()) {
             appendSitemapUrl(xml, baseUrl + "/projects/" + project.slug());
         }

--- a/src/main/java/com/codernawaki/portfolio/SecurityConfig.java
+++ b/src/main/java/com/codernawaki/portfolio/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.ignoringRequestMatchers("/submitContactForm"))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/style.css", "/script.js", "/image.png", "/robots.txt").permitAll()
-                        .requestMatchers("/", "/login", "/submitContactForm").permitAll()
+                        .requestMatchers("/", "/login", "/submitContactForm", "/blog/**").permitAll()
                         .requestMatchers("/actuator/health/**", "/actuator/info", "/actuator/prometheus").permitAll()
                         .requestMatchers("/actuator/**").hasRole("ADMIN")
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()

--- a/src/main/resources/templates/blog/detail.html
+++ b/src/main/resources/templates/blog/detail.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments :: head}"></head>
+<body>
+<header th:replace="~{fragments :: header}"></header>
+
+<main>
+    <section class="section blog-detail-section">
+        <nav class="breadcrumb">
+            <a th:href="@{/blog}">Blog</a>
+            <span th:text="' / ' + ${article.title}">Article title</span>
+        </nav>
+
+        <article class="blog-article">
+            <header class="blog-article-header">
+                <h1 th:text="${article.title}">Article title</h1>
+                <div class="blog-article-meta">
+                    <time th:datetime="${article.publishedAt}" th:text="${#temporals.format(article.publishedAt, 'MMM d, yyyy')}">Date</time>
+                    <span th:if="${article.tags != null and !article.tags.isEmpty()}">
+                        <span class="blog-tag" th:each="tag : ${#strings.listSplit(article.tags, ',')}" th:text="${#strings.trim(tag)}">tag</span>
+                    </span>
+                </div>
+            </header>
+
+            <div class="blog-article-content" th:utext="${htmlContent}">
+                Rendered HTML content
+            </div>
+        </article>
+
+        <div class="blog-back-link">
+            <a th:href="@{/blog}">&larr; Back to Blog</a>
+        </div>
+    </section>
+</main>
+
+<button id="scrollToTopBtn" type="button" aria-label="Scroll to top">Top</button>
+
+<footer th:replace="~{fragments :: footer}"></footer>
+
+<script th:src="@{/script.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/blog/list.html
+++ b/src/main/resources/templates/blog/list.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments :: head}"></head>
+<body>
+<header th:replace="~{fragments :: header}"></header>
+
+<main>
+    <section class="section blog-list-section">
+        <div class="section-heading">
+            <p class="eyebrow">Blog</p>
+            <h1>Articles and case studies</h1>
+        </div>
+
+        <div class="blog-toolbar">
+            <span class="blog-count" th:text="${articlesPage.totalElements} + ' article' + (${articlesPage.totalElements} == 1 ? '' : 's')">0 articles</span>
+        </div>
+
+        <div th:if="${#lists.isEmpty(articles)}" class="blog-empty">
+            <p>No articles published yet.</p>
+        </div>
+
+        <div th:unless="${#lists.isEmpty(articles)}" class="blog-list">
+            <article class="blog-card" th:each="article : ${articles}">
+                <h2 class="blog-card-title">
+                    <a th:href="@{/blog/{slug}(slug=${article.slug})}" th:text="${article.title}">Article title</a>
+                </h2>
+                <p class="blog-card-excerpt" th:text="${article.excerpt}">Excerpt</p>
+                <div class="blog-card-meta">
+                    <time th:datetime="${article.publishedAt}" th:text="${#temporals.format(article.publishedAt, 'MMM d, yyyy')}">Date</time>
+                    <span th:if="${article.tags != null and !article.tags.isEmpty()}" class="blog-card-tags">
+                        <span class="blog-tag" th:each="tag : ${#strings.listSplit(article.tags, ',')}" th:text="${#strings.trim(tag)}">tag</span>
+                    </span>
+                </div>
+            </article>
+        </div>
+
+        <div th:if="${articlesPage.totalPages > 1}" class="blog-pagination">
+            <span th:if="${articlesPage.hasPrevious()}">
+                <a th:href="@{/blog(page=${articlesPage.number - 1})}" class="pagination-link">&laquo; Previous</a>
+            </span>
+            <span class="pagination-info" th:text="'Page ' + (${articlesPage.number} + 1) + ' of ' + ${articlesPage.totalPages}">Page 1 of 1</span>
+            <span th:if="${articlesPage.hasNext()}">
+                <a th:href="@{/blog(page=${articlesPage.number + 1})}" class="pagination-link">Next &raquo;</a>
+            </span>
+        </div>
+    </section>
+</main>
+
+<button id="scrollToTopBtn" type="button" aria-label="Scroll to top">Top</button>
+
+<footer th:replace="~{fragments :: footer}"></footer>
+
+<script th:src="@{/script.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -49,6 +49,7 @@
         <a th:href="@{/#about}">About</a>
         <a th:href="@{/#skills}">Skills</a>
         <a th:href="@{/#projects}">Projects</a>
+        <a th:href="@{/blog}">Blog</a>
         <a th:href="@{/#contact}">Contact</a>
         <a sec:authorize="isAuthenticated()" th:href="@{/admin/contact-submissions}" class="admin-link">Inbox</a>
         <button id="themeToggle" class="theme-toggle-btn" type="button" aria-label="Toggle theme">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -87,6 +87,25 @@
         </div>
     </section>
 
+    <section class="section reveal" th:if="${not #lists.isEmpty(latestPosts)}" id="latest-posts">
+        <div class="section-heading">
+            <p class="eyebrow">Latest Posts</p>
+            <h2>Recent articles and case studies</h2>
+        </div>
+        <div class="latest-posts-grid">
+            <article class="latest-post-card" th:each="post : ${latestPosts}">
+                <h3>
+                    <a th:href="@{/blog/{slug}(slug=${post.slug})}" th:text="${post.title}">Post title</a>
+                </h3>
+                <p th:text="${post.excerpt}">Excerpt</p>
+                <time th:datetime="${post.publishedAt}" th:text="${#temporals.format(post.publishedAt, 'MMM d, yyyy')}">Date</time>
+            </article>
+        </div>
+        <div class="section-footer-link">
+            <a th:href="@{/blog}">View all articles &rarr;</a>
+        </div>
+    </section>
+
     <section class="section reveal" id="skills">
         <div class="section-heading">
             <p class="eyebrow">Skills</p>


### PR DESCRIPTION
### Summary

Implements public-facing blog pages, navigation updates, and homepage integration for Sprint 2 (#67).

### Changes

- **BlogController**: `GET /blog` (paginated list) and `GET /blog/{slug}` (detail with rendered Markdown)
- **Templates**: `blog/list.html` (pagination, tag display) and `blog/detail.html` (breadcrumb, rendered HTML content)
- **BlogService**: Added `getLatestPublishedArticles(int count)`
- **HomeController**: Injected `BlogService`, shows latest 3 posts on homepage, adds blog URLs to sitemap
- **Navigation**: Blog link added to site header
- **Security**: `/blog/**` permitted publicly

### Verification

- `./gradlew compileJava` passes