### PR TITLE
Sprint 4 (#69): Tag filter, RSS feed, and blog CSS

### DIFF
--- a/src/main/java/com/codernawaki/portfolio/BlogController.java
+++ b/src/main/java/com/codernawaki/portfolio/BlogController.java
@@ -1,11 +1,15 @@
 package com.codernawaki.portfolio;
 
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
 
@@ -25,13 +29,15 @@ public class BlogController {
     @GetMapping("/blog")
     public String blogList(
             @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) String tag,
             Model model) {
         PortfolioProperties props = portfolioService.getProperties();
-        var articlesPage = blogService.getPublishedArticles(PageRequest.of(page, ARTICLES_PER_PAGE));
+        var articlesPage = blogService.getPublishedArticles(PageRequest.of(page, ARTICLES_PER_PAGE), tag);
 
         model.addAttribute("articlesPage", articlesPage);
         model.addAttribute("articles", articlesPage.getContent());
-        model.addAttribute("pageTitle", "Blog | " + props.getDisplayName());
+        model.addAttribute("currentTag", tag);
+        model.addAttribute("pageTitle", tag != null ? tag + " | Blog | " + props.getDisplayName() : "Blog | " + props.getDisplayName());
         model.addAttribute("pageDescription", "Articles and case studies from a full stack developer in Japan.");
         model.addAttribute("pageUrl", props.getSiteUrl() + "/blog");
         return "blog/list";
@@ -50,5 +56,51 @@ public class BlogController {
                 article.getExcerpt() != null ? article.getExcerpt() : article.getTitle());
         model.addAttribute("pageUrl", props.getSiteUrl() + "/blog/" + article.getSlug());
         return "blog/detail";
+    }
+
+    @GetMapping(value = "/blog/feed.xml", produces = "application/xml")
+    @ResponseBody
+    public String rssFeed() {
+        PortfolioProperties props = portfolioService.getProperties();
+        String baseUrl = props.getSiteUrl();
+        List<Article> articles = blogService.getAllPublishedArticles();
+        DateTimeFormatter dateFormat = DateTimeFormatter.RFC_1123_DATE_TIME;
+
+        StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        xml.append("<rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\">");
+        xml.append("<channel>");
+        xml.append("<title>").append(xmlEscape(props.getDisplayName())).append(" Blog</title>");
+        xml.append("<link>").append(xmlEscape(baseUrl)).append("/blog</link>");
+        xml.append("<description>Articles and case studies from a full stack developer in Japan.</description>");
+        xml.append("<atom:link href=\"").append(xmlEscape(baseUrl)).append("/blog/feed.xml\" rel=\"self\" type=\"application/rss+xml\"/>");
+
+        for (Article article : articles) {
+            xml.append("<item>");
+            xml.append("<title>").append(xmlEscape(article.getTitle())).append("</title>");
+            xml.append("<link>").append(xmlEscape(baseUrl)).append("/blog/").append(xmlEscape(article.getSlug())).append("</link>");
+            xml.append("<guid>").append(xmlEscape(baseUrl)).append("/blog/").append(xmlEscape(article.getSlug())).append("</guid>");
+            if (article.getExcerpt() != null) {
+                xml.append("<description>").append(xmlEscape(article.getExcerpt())).append("</description>");
+            }
+            if (article.getPublishedAt() != null) {
+                xml.append("<pubDate>").append(dateFormat.format(article.getPublishedAt())).append("</pubDate>");
+            }
+            xml.append("</item>");
+        }
+
+        xml.append("</channel>");
+        xml.append("</rss>");
+        return xml.toString();
+    }
+
+    private String xmlEscape(String value) {
+        if (value == null) return "";
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
     }
 }

--- a/src/main/java/com/codernawaki/portfolio/BlogService.java
+++ b/src/main/java/com/codernawaki/portfolio/BlogService.java
@@ -34,11 +34,24 @@ public class BlogService {
     }
 
     public Page<Article> getPublishedArticles(Pageable pageable) {
+        return getPublishedArticles(pageable, null);
+    }
+
+    public Page<Article> getPublishedArticles(Pageable pageable, String tag) {
         Pageable sorted = PageRequest.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize(),
                 PUBLISHED_SORT);
+        if (tag != null && !tag.isBlank()) {
+            String searchPattern = "%" + tag.trim().toLowerCase() + "%";
+            return articleRepository.findByStatusAndTag(ArticleStatus.PUBLISHED, searchPattern, sorted);
+        }
         return articleRepository.findByStatus(ArticleStatus.PUBLISHED, sorted);
+    }
+
+    public List<Article> getAllPublishedArticles() {
+        Pageable all = PageRequest.of(0, 100, PUBLISHED_SORT);
+        return articleRepository.findByStatus(ArticleStatus.PUBLISHED, all).getContent();
     }
 
     public List<Article> getLatestPublishedArticles(int count) {

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -655,3 +655,71 @@ main { padding: 2rem 0 5rem; }
 /* Skills & Chips */
 .chip-row { display: flex; gap: 0.6rem; flex-wrap: wrap; margin: 1rem 0; }
 .chip { padding: 0.3rem 0.8rem; background: var(--surface-strong); border-radius: 999px; font-size: 0.85rem; font-weight: 600; color: var(--accent-dark); }
+
+/* Blog: List */
+.blog-list-section { max-width: var(--content-width); margin: 0 auto; padding: 2rem 1.5rem; }
+.blog-list { display: flex; flex-direction: column; gap: 2rem; }
+.blog-card { padding: 1.5rem; background: var(--surface); border-radius: var(--radius-md); border: 1px solid var(--line); }
+.blog-card-title { margin: 0 0 0.5rem; font-size: 1.3rem; }
+.blog-card-title a { color: var(--ink); text-decoration: none; }
+.blog-card-title a:hover { color: var(--accent); }
+.blog-card-excerpt { color: var(--muted); margin: 0 0 0.75rem; }
+.blog-card-meta { display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; font-size: 0.9rem; color: var(--muted); }
+.blog-card-tags { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+.blog-tag { display: inline-block; padding: 0.15rem 0.5rem; background: var(--accent-soft); border-radius: 999px; font-size: 0.8rem; font-weight: 600; color: var(--accent-dark); text-decoration: none; }
+.blog-tag:hover { background: var(--accent); color: #fff; }
+.blog-toolbar { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; margin-bottom: 2rem; }
+.blog-count { font-size: 0.95rem; color: var(--muted); }
+.blog-tag-filter { display: flex; gap: 0.5rem; align-items: center; }
+.blog-tag-input { padding: 0.4rem 0.75rem; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); color: var(--ink); font-size: 0.9rem; }
+.blog-tag-submit { padding: 0.4rem 0.75rem; border: 1px solid var(--accent); border-radius: var(--radius-md); background: var(--accent); color: #fff; font-size: 0.9rem; cursor: pointer; }
+.blog-tag-submit:hover { background: var(--accent-dark); }
+.blog-tag-clear { padding: 0.4rem 0.75rem; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); color: var(--muted); font-size: 0.9rem; text-decoration: none; }
+.blog-tag-clear:hover { color: var(--accent); }
+.blog-active-filter { margin-bottom: 1.5rem; padding: 0.5rem 1rem; background: var(--accent-soft); border-radius: var(--radius-md); font-size: 0.9rem; color: var(--accent-dark); }
+.blog-empty { padding: 3rem; text-align: center; color: var(--muted); }
+.blog-pagination { display: flex; justify-content: center; align-items: center; gap: 1rem; margin-top: 2rem; }
+.pagination-link { color: var(--accent); text-decoration: none; font-weight: 600; }
+.pagination-link:hover { text-decoration: underline; }
+.pagination-info { font-size: 0.9rem; color: var(--muted); }
+
+/* Blog: Detail */
+.blog-detail-section { max-width: 780px; margin: 0 auto; padding: 2rem 1.5rem; }
+.breadcrumb { font-size: 0.9rem; color: var(--muted); margin-bottom: 2rem; }
+.breadcrumb a { color: var(--accent); text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
+.blog-article-header { margin-bottom: 2rem; }
+.blog-article-header h1 { margin: 0 0 0.5rem; font-size: 2rem; }
+.blog-article-meta { display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; font-size: 0.9rem; color: var(--muted); }
+.blog-article-content { line-height: 1.8; font-size: 1.05rem; }
+.blog-article-content h2 { margin-top: 2rem; }
+.blog-article-content h3 { margin-top: 1.5rem; }
+.blog-article-content p { margin: 1rem 0; }
+.blog-article-content pre { background: var(--surface); padding: 1rem; border-radius: var(--radius-md); overflow-x: auto; border: 1px solid var(--line); }
+.blog-article-content code { font-size: 0.9em; background: var(--surface-strong); padding: 0.15rem 0.35rem; border-radius: 4px; }
+.blog-article-content pre code { background: transparent; padding: 0; }
+.blog-article-content img { max-width: 100%; border-radius: var(--radius-md); }
+.blog-article-content blockquote { border-left: 3px solid var(--accent); margin: 1rem 0; padding: 0.5rem 1rem; background: var(--surface); border-radius: 0 var(--radius-md) var(--radius-md) 0; color: var(--muted); }
+.blog-back-link { margin-top: 3rem; }
+.blog-back-link a { color: var(--accent); text-decoration: none; font-weight: 600; }
+.blog-back-link a:hover { text-decoration: underline; }
+
+/* Home: Latest Posts */
+.latest-posts-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem; margin-top: 2rem; }
+.latest-post-card { padding: 1.5rem; background: var(--surface); border-radius: var(--radius-md); border: 1px solid var(--line); }
+.latest-post-card h3 { margin: 0 0 0.5rem; font-size: 1.1rem; }
+.latest-post-card h3 a { color: var(--ink); text-decoration: none; }
+.latest-post-card h3 a:hover { color: var(--accent); }
+.latest-post-card p { color: var(--muted); font-size: 0.95rem; margin: 0 0 0.5rem; }
+.latest-post-card time { font-size: 0.85rem; color: var(--muted); }
+.section-footer-link { margin-top: 1.5rem; text-align: center; }
+.section-footer-link a { color: var(--accent); font-weight: 600; text-decoration: none; }
+.section-footer-link a:hover { text-decoration: underline; }
+
+/* Admin: Article Form */
+.article-form label { display: flex; flex-direction: column; gap: 0.3rem; margin-bottom: 1rem; font-size: 0.9rem; color: var(--muted); }
+.article-form input[type="text"],
+.article-form textarea { padding: 0.5rem 0.75rem; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); color: var(--ink); font-family: inherit; font-size: 0.95rem; }
+.article-form textarea { resize: vertical; }
+.article-form .checkbox-label { flex-direction: row; align-items: center; gap: 0.5rem; cursor: pointer; }
+.article-form .checkbox-label input[type="checkbox"] { width: 1.1rem; height: 1.1rem; cursor: pointer; }

--- a/src/main/resources/templates/blog/list.html
+++ b/src/main/resources/templates/blog/list.html
@@ -13,6 +13,15 @@
 
         <div class="blog-toolbar">
             <span class="blog-count" th:text="${articlesPage.totalElements} + ' article' + (${articlesPage.totalElements} == 1 ? '' : 's')">0 articles</span>
+            <form class="blog-tag-filter" method="get" th:action="@{/blog}">
+                <input type="search" name="tag" th:value="${currentTag}" placeholder="Filter by tag..." class="blog-tag-input">
+                <button type="submit" class="blog-tag-submit">Filter</button>
+                <a th:if="${currentTag != null}" th:href="@{/blog}" class="blog-tag-clear">Clear</a>
+            </form>
+        </div>
+
+        <div th:if="${currentTag != null}" class="blog-active-filter">
+            Filtering by tag: <strong th:text="${currentTag}">tag</strong>
         </div>
 
         <div th:if="${#lists.isEmpty(articles)}" class="blog-empty">
@@ -28,7 +37,7 @@
                 <div class="blog-card-meta">
                     <time th:datetime="${article.publishedAt}" th:text="${#temporals.format(article.publishedAt, 'MMM d, yyyy')}">Date</time>
                     <span th:if="${article.tags != null and !article.tags.isEmpty()}" class="blog-card-tags">
-                        <span class="blog-tag" th:each="tag : ${#strings.listSplit(article.tags, ',')}" th:text="${#strings.trim(tag)}">tag</span>
+                        <a class="blog-tag" th:each="tag : ${#strings.listSplit(article.tags, ',')}" th:href="@{/blog(tag=${#strings.trim(tag)})}" th:text="${#strings.trim(tag)}">tag</a>
                     </span>
                 </div>
             </article>
@@ -36,11 +45,11 @@
 
         <div th:if="${articlesPage.totalPages > 1}" class="blog-pagination">
             <span th:if="${articlesPage.hasPrevious()}">
-                <a th:href="@{/blog(page=${articlesPage.number - 1})}" class="pagination-link">&laquo; Previous</a>
+                <a th:href="@{/blog(page=${articlesPage.number - 1}, tag=${currentTag})}" class="pagination-link">&laquo; Previous</a>
             </span>
             <span class="pagination-info" th:text="'Page ' + (${articlesPage.number} + 1) + ' of ' + ${articlesPage.totalPages}">Page 1 of 1</span>
             <span th:if="${articlesPage.hasNext()}">
-                <a th:href="@{/blog(page=${articlesPage.number + 1})}" class="pagination-link">Next &raquo;</a>
+                <a th:href="@{/blog(page=${articlesPage.number + 1}, tag=${currentTag})}" class="pagination-link">Next &raquo;</a>
             </span>
         </div>
     </section>


### PR DESCRIPTION
### Summary

Adds tag-based filtering, RSS feed, and blog CSS as part of Sprint 4 (#69).

### Changes

- **BlogService**: Added `getPublishedArticles(pageable, tag)` with tag-filter via `findByStatusAndTag`, and `getAllPublishedArticles()` for RSS
- **BlogController**: Added `tag` param to `blogList`, added `/blog/feed.xml` RSS endpoint
- **blog/list.html**: Tag filter form, active filter indicator, tag links on article cards, tag-preserving pagination
- **style.css**: Full blog component styles (list, detail, latest posts, admin article form)

### Verification

- `./gradlew compileJava` passes