### PR TITLE
fix: upgrade OpenTelemetry to 1.62.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ configurations.all {
 		if (details.requested.group == 'io.netty') {
 			details.useVersion '4.2.13.Final'
 		}
+		if (details.requested.group == 'io.opentelemetry') {
+			details.useVersion '1.62.0'
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #77

Upgrades `io.opentelemetry:*` from 1.55.0 (managed by Spring Boot 4.0.6) to 1.62.0 via resolutionStrategy.

**Vulnerability:** GHSA-rcgg-9c38-7xpx — Unbounded Memory Allocation in W3C Baggage Propagation that could lead to denial of service.

**Change:** Added `resolutionStrategy.eachDependency` rule for `io.opentelemetry` group to force version 1.62.0.