### PR TITLE
fix: downgrade commons-lang3 to 3.18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 	implementation 'org.apache.tomcat.embed:tomcat-embed-core:11.0.22'
 	implementation 'org.apache.tomcat.embed:tomcat-embed-el:11.0.22'
 	implementation 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.22'
-	implementation 'org.apache.commons:commons-lang3:3.20.0'
+	implementation 'org.apache.commons:commons-lang3:3.18.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'com.vladsch.flexmark:flexmark-all:0.64.8'


### PR DESCRIPTION
Closes #78

Downgrades `org.apache.commons:commons-lang3` from 3.20.0 to 3.18.0 to resolve Uncontrolled Recursion (StackOverflowError) in ClassUtils.

The first patched version for this CVE is 3.18.0.