### PR TITLE
fix: upgrade Netty to 4.2.15.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ configurations {
 configurations.all {
 	resolutionStrategy.eachDependency { DependencyResolveDetails details ->
 		if (details.requested.group == 'io.netty') {
-			details.useVersion '4.2.13.Final'
+			details.useVersion '4.2.15.Final'
 		}
 		if (details.requested.group == 'io.opentelemetry') {
 			details.useVersion '1.62.0'


### PR DESCRIPTION
Closes #79

Bumps the forced Netty version from `4.2.13.Final` to `4.2.15.Final` in `resolutionStrategy`.

Fixes 5 open Dependabot alerts:
- **GHSA-5pvg-856g-cp85** — Insufficient Bailiwick Validation for NS Records
- **GHSA-676x-f7gg-47vc** — Missing Bailiwick Checks in CNAME Records
- **GHSA-xmv7-r254-6q78** — DNS Cache Poisoning due to Predictable PRNG
- **GHSA-x4gw-5cx5-pgmh** — SNI handler pre-allocates up to 16 MiB
- **GHSA-3qp7-7mw8-wx86** — IPv6 Subnet Filter Bypass