### PR TITLE
feat: replace docker-compose wrapper with native Docker provider in Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ plan.md
 /infra/terraform/terraform.tfstate.backup
 /infra/terraform/.terraform/
 *.tfstate
+*.tfvars
 
 # Local env
 .env

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -20,3 +20,24 @@ provider "registry.terraform.io/hashicorp/null" {
     "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
   ]
 }
+
+provider "registry.terraform.io/kreuzwerker/docker" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:p65AjYSOmmHPjKkIYlEnxSMyrprTHKf1qBzKhCnCtG8=",
+    "zh:0ead8281830e9b9496651282235d9a139ba1b1b6ff79e395eb8c78658dc446b9",
+    "zh:0f17d37d8d3872df3fb75c68b5272e0c981343f53b506a9675b4405191edd3ef",
+    "zh:11d50b37323874427c6d2a08b737d3c7707c8301fdd236c94485cf2828d0b14b",
+    "zh:32f6f9b847446054e2db3d72886ef2f1d1aa51a6d0dac42340b07dad18e3f28f",
+    "zh:5ea5c67668b5dcbda560dc6104b788a9bfc974d52f02f7886889b77cc0e5d248",
+    "zh:5fb19a0b07edc344cd3ddeeb9cfb3d183089deb7a6a94a7b22a583aa1712596b",
+    "zh:602a7ece444e2a142ec5245abb98e7a1a990a68afae2df63b6c85ec084f0c5d7",
+    "zh:693dce278524ad8a6d6c9dd7a01bcd63bb85189639198f8d0b044ab0e5099401",
+    "zh:72e9911568103576c6a78fa38841cfd45eeb88ad22a2c649eb140a377a5b3c26",
+    "zh:956b62b6857cbb467b50158601f01b1203daa34cbd447dcc7f044c327e878b68",
+    "zh:9d372bac0d4479868b34485fb4966ba7bb525938f818b6a625f4977004ea83f9",
+    "zh:e06658a51427f9f53dbdb06263406fc1bc56d1a4fb5e7eb660d7cdfc22f596bd",
+    "zh:eee38dadf672b946419af25160eae7c03fc2afbb14f39f2f1d2a7404d647e2f7",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,24 +1,60 @@
-Terraform to manage local docker-compose deployment
+Terraform — Local Docker Deployment
+=====================================
 
-This Terraform configuration uses a null_resource with local-exec provisioners to run docker compose for this repository's docker-compose.yml.
+This Terraform configuration manages the full Portfolio stack using the
+[Docker provider](https://registry.terraform.io/providers/kreuzwerker/docker)
+instead of shelling out to `docker compose`.
+
+Prerequisites
+-------------
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
+- Docker Desktop (or Docker engine) running locally
+- Environment variables set (or update `terraform.tfvars`):
+  - `TF_VAR_admin_username` – admin login username
+  - `TF_VAR_admin_password` – admin login password
 
 Usage
+-----
+```bash
+cd infra/terraform
 
-1. Install Terraform (>= 1.0)
-2. From repo root, run:
+# Initialise (downloads the Docker provider plugin)
+terraform init
 
-   cd infra/terraform
-   terraform init
-   terraform apply
+# Preview what will be created
+terraform plan
 
-This will run: docker compose -f <repo-root>/docker-compose.yml pull && docker compose -f <repo-root>/docker-compose.yml up -d
+# Build images, create network/volumes, start all containers
+terraform apply
 
-To tear down the compose stack:
+# Tear down the entire stack (containers, network, volumes)
+terraform destroy
+```
 
-   terraform destroy
+What is managed
+---------------
+| Resource  | Description                          |
+|-----------|--------------------------------------|
+| Network   | `portfolio-network` (bridge)         |
+| Volumes   | `postgres-data`, `grafana-storage`   |
+| Images    | All 8 Docker images (build or pull)  |
+| Containers| App, PostgreSQL, Redis, Prometheus, Grafana, Loki, Tempo, Promtail |
 
-Notes
+Differences from docker-compose
+-------------------------------
+- Containers are managed individually rather than as a Compose project.
+- Health-based dependency ordering is emulated with a `null_resource` waiter
+  for PostgreSQL and Redis before the app starts.
+- The app image is rebuilt only when `Dockerfile` or `build.gradle` changes
+  (driven by Terraform's `triggers`).
+- Run `terraform destroy` to remove all managed resources.
 
-- Terraform uses local-exec; it requires Docker and Docker Compose available on the machine running Terraform.
-- State is stored locally by default. For collaboration, configure a remote backend (e.g., S3, Terraform Cloud).
-- This is intentionally minimal (learning resource). Future iterations can use the Docker provider or Kubernetes provider as needed.
+Access points
+-------------
+| Service    | URL                          |
+|------------|------------------------------|
+| App        | http://localhost:8081        |
+| Prometheus | http://localhost:9090        |
+| Grafana    | http://localhost:3000        |
+| Loki       | http://localhost:3100        |
+| Tempo      | http://localhost:3200        |

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,21 +1,317 @@
 terraform {
   required_version = ">= 1.0"
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
+  }
 }
 
-resource "null_resource" "deploy" {
-  # change triggers to force re-run when apply is called
+provider "docker" {
+  host = var.docker_host
+}
+
+# ---------------------------------------------------------------------------
+# Network
+# ---------------------------------------------------------------------------
+resource "docker_network" "portfolio" {
+  name   = "portfolio-network"
+  driver = "bridge"
+}
+
+# ---------------------------------------------------------------------------
+# Volumes
+# ---------------------------------------------------------------------------
+resource "docker_volume" "postgres_data" {
+  name = "postgres-data"
+}
+
+resource "docker_volume" "grafana_storage" {
+  name = "grafana-storage"
+}
+
+# ---------------------------------------------------------------------------
+# Images – pulled from registries
+# ---------------------------------------------------------------------------
+resource "docker_image" "postgres" {
+  name         = "postgres:16-alpine"
+  keep_locally = true
+}
+
+resource "docker_image" "redis" {
+  name         = "redis:7-alpine"
+  keep_locally = true
+}
+
+resource "docker_image" "prometheus" {
+  name         = "prom/prometheus"
+  keep_locally = true
+}
+
+resource "docker_image" "grafana" {
+  name         = "grafana/grafana-oss"
+  keep_locally = true
+}
+
+resource "docker_image" "loki" {
+  name         = "grafana/loki:latest"
+  keep_locally = true
+}
+
+resource "docker_image" "tempo" {
+  name         = "grafana/tempo:2.3.1"
+  keep_locally = true
+}
+
+resource "docker_image" "promtail" {
+  name         = "grafana/promtail:latest"
+  keep_locally = true
+}
+
+# ---------------------------------------------------------------------------
+# Image – built locally from Dockerfile
+# ---------------------------------------------------------------------------
+resource "docker_image" "portfolio_app" {
+  name = var.image_tag
+  build {
+    context    = "${path.module}/../.."
+    dockerfile = "Dockerfile"
+  }
+
   triggers = {
-    always_run = timestamp()
+    dockerfile_sha1 = sha1(file("${path.module}/../../Dockerfile"))
+    gradle_sha1     = sha1(join("", [for f in fileset("${path.module}/../..", "build.gradle") : file("${path.module}/../../${f}")]))
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Containers – ordered to respect inter-dependencies
+# ---------------------------------------------------------------------------
+resource "docker_container" "db" {
+  name  = "portfolio-db"
+  image = docker_image.postgres.name
+
+  env = [
+    "POSTGRES_DB=portfolio",
+    "POSTGRES_USER=portfolio_user",
+    "POSTGRES_PASSWORD=portfolio_pass",
+  ]
+
+  volumes {
+    volume_name    = docker_volume.postgres_data.name
+    container_path = "/var/lib/postgresql/data"
   }
 
-  provisioner "local-exec" {
-    working_dir = "${path.module}/../.."
-    command     = "docker compose pull && docker compose up -d"
+  networks_advanced {
+    name = docker_network.portfolio.name
   }
 
-  provisioner "local-exec" {
-    when        = destroy
-    working_dir = "${path.module}/../.."
-    command     = "docker compose down"
+  healthcheck {
+    test     = ["CMD-SHELL", "pg_isready -U portfolio_user -d portfolio"]
+    interval = "5s"
+    timeout  = "5s"
+    retries  = 5
   }
+
+  restart = "unless-stopped"
+}
+
+resource "docker_container" "redis" {
+  name  = "portfolio-redis"
+  image = docker_image.redis.name
+
+  networks_advanced {
+    name = docker_network.portfolio.name
+  }
+
+  healthcheck {
+    test     = ["CMD", "redis-cli", "ping"]
+    interval = "5s"
+    timeout  = "3s"
+    retries  = 10
+  }
+
+  restart = "unless-stopped"
+}
+
+# Wait for PostgreSQL and Redis to be healthy before starting the app.
+resource "null_resource" "wait_for_dependencies" {
+  depends_on = [docker_container.db, docker_container.redis]
+
+  provisioner "local-exec" {
+    command = "${path.module}/wait-for-dependencies.sh"
+  }
+
+  triggers = {
+    db_image    = docker_image.postgres.name
+    redis_image = docker_image.redis.name
+  }
+}
+
+resource "docker_container" "portfolio_app" {
+  depends_on = [null_resource.wait_for_dependencies]
+
+  name  = "portfolio-app"
+  image = docker_image.portfolio_app.name
+
+  ports {
+    internal = 8081
+    external = 8081
+  }
+
+  env = [
+    "PORTFOLIO_ADMIN_USERNAME=${var.admin_username}",
+    "PORTFOLIO_ADMIN_PASSWORD=${var.admin_password}",
+    "SPRING_DATASOURCE_URL=jdbc:postgresql://portfolio-db:5432/portfolio",
+    "SPRING_DATASOURCE_USERNAME=portfolio_user",
+    "SPRING_DATASOURCE_PASSWORD=portfolio_pass",
+    "SPRING_DATA_REDIS_HOST=portfolio-redis",
+    "SPRING_DATA_REDIS_PORT=6379",
+    "MANAGEMENT_OPENTELEMETRY_TRACING_EXPORT_OTLP_ENDPOINT=http://portfolio-tempo:4318/v1/traces",
+  ]
+
+  networks_advanced {
+    name = docker_network.portfolio.name
+  }
+
+  log_driver = "json-file"
+  log_opts = {
+    tag = "{{.Name}}"
+  }
+
+  restart = "unless-stopped"
+}
+
+resource "docker_container" "prometheus" {
+  depends_on = [docker_container.portfolio_app]
+
+  name  = "portfolio-prometheus"
+  image = docker_image.prometheus.name
+
+  ports {
+    internal = 9090
+    external = 9090
+  }
+
+  volumes {
+    host_path      = abspath("${path.module}/../../prometheus.yml")
+    container_path = "/etc/prometheus/prometheus.yml"
+  }
+
+  networks_advanced {
+    name = docker_network.portfolio.name
+  }
+
+  restart = "unless-stopped"
+}
+
+resource "docker_container" "loki" {
+  name  = "portfolio-loki"
+  image = docker_image.loki.name
+
+  ports {
+    internal = 3100
+    external = 3100
+  }
+
+  command = ["-config.file=/etc/loki/local-config.yaml"]
+
+  networks_advanced {
+    name = docker_network.portfolio.name
+  }
+
+  restart = "unless-stopped"
+}
+
+resource "docker_container" "tempo" {
+  name  = "portfolio-tempo"
+  image = docker_image.tempo.name
+
+  ports {
+    internal = 3200
+    external = 3200
+  }
+  ports {
+    internal = 4318
+    external = 4318
+  }
+
+  command = ["-config.file=/etc/tempo.yaml"]
+
+  volumes {
+    host_path      = abspath("${path.module}/../../tempo/tempo.yml")
+    container_path = "/etc/tempo.yaml"
+  }
+
+  networks_advanced {
+    name = docker_network.portfolio.name
+  }
+
+  restart = "unless-stopped"
+}
+
+resource "docker_container" "promtail" {
+  depends_on = [docker_container.loki]
+
+  name  = "portfolio-promtail"
+  image = docker_image.promtail.name
+
+  user = "root"
+
+  volumes {
+    host_path      = "/var/lib/docker/containers"
+    container_path = "/var/lib/docker/containers"
+    read_only      = true
+  }
+  volumes {
+    host_path      = "/var/run/docker.sock"
+    container_path = "/var/run/docker.sock"
+    read_only      = true
+  }
+  volumes {
+    host_path      = abspath("${path.module}/../../promtail-config.yml")
+    container_path = "/etc/promtail/config.yml"
+  }
+
+  command = ["-config.file=/etc/promtail/config.yml"]
+
+  networks_advanced {
+    name = docker_network.portfolio.name
+  }
+
+  restart = "unless-stopped"
+}
+
+resource "docker_container" "grafana" {
+  depends_on = [docker_container.prometheus, docker_container.loki, docker_container.tempo]
+
+  name  = "portfolio-grafana"
+  image = docker_image.grafana.name
+
+  ports {
+    internal = 3000
+    external = 3000
+  }
+
+  volumes {
+    volume_name    = docker_volume.grafana_storage.name
+    container_path = "/var/lib/grafana"
+  }
+  volumes {
+    host_path      = abspath("${path.module}/../../grafana/provisioning")
+    container_path = "/etc/grafana/provisioning"
+    read_only      = true
+  }
+  volumes {
+    host_path      = abspath("${path.module}/../../grafana/dashboards")
+    container_path = "/var/lib/grafana/dashboards"
+    read_only      = true
+  }
+
+  networks_advanced {
+    name = docker_network.portfolio.name
+  }
+
+  restart = "unless-stopped"
 }

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "portfolio_app_url" {
+  description = "Portfolio application URL"
+  value       = "http://localhost:8081"
+}
+
+output "prometheus_url" {
+  description = "Prometheus dashboard URL"
+  value       = "http://localhost:9090"
+}
+
+output "grafana_url" {
+  description = "Grafana dashboard URL"
+  value       = "http://localhost:3000"
+}
+
+output "loki_url" {
+  description = "Loki HTTP API URL"
+  value       = "http://localhost:3100"
+}
+
+output "tempo_url" {
+  description = "Tempo HTTP API URL"
+  value       = "http://localhost:3200"
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,2 @@
+admin_username = "admin"
+admin_password = "change_me"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "admin_username" {
+  type        = string
+  description = "Portfolio admin username"
+  sensitive   = false
+}
+
+variable "admin_password" {
+  type        = string
+  description = "Portfolio admin password"
+  sensitive   = true
+}
+
+variable "docker_host" {
+  type        = string
+  description = "Docker daemon socket to connect to"
+  default     = "unix:///var/run/docker.sock"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Tag for the locally built portfolio-app image"
+  default     = "portfolio-app:latest"
+}

--- a/infra/terraform/wait-for-dependencies.sh
+++ b/infra/terraform/wait-for-dependencies.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+echo "Waiting for PostgreSQL..."
+until docker exec portfolio-db pg_isready -U portfolio_user -d portfolio 2>/dev/null; do
+  sleep 2
+done
+echo "PostgreSQL is ready."
+
+echo "Waiting for Redis..."
+until docker exec portfolio-redis redis-cli ping 2>/dev/null | grep -q PONG; do
+  sleep 2
+done
+echo "Redis is ready."


### PR DESCRIPTION
Rewrite infra/terraform/ to use the `kreuzwerker/docker` provider instead of shelling out to `docker compose` via `null_resource` + `local-exec`.

### What changed
- Added Docker provider with  and variable-based configuration
- Managed network, volumes, images, and containers as native Terraform resources
- App image is built from Dockerfile with change-tracking triggers (Dockerfile, build.gradle)
- All service images are pulled automatically (PostgreSQL, Redis, Prometheus, Grafana, Loki, Tempo, Promtail)
- Added health-check waiter script for ordered startup (PostgreSQL → Redis → app)
- Added `variables.tf`, `outputs.tf`, `terraform.tfvars.example` for clean configuration
- Updated README with full usage and resource table
- Gitignored `*.tfvars` to prevent secret leaks

### How to use
```bash
cd infra/terraform
terraform init
terraform apply   # builds images, starts all containers
terraform destroy # tears down everything
```

### Related
Closes the issue where terraform was not runnable and relied on `docker compose` separately.