### PR TITLE
feat: add skill definitions for opencode agents

### DIFF
--- a/.claude/skills/bug-fix/SKILL.md
+++ b/.claude/skills/bug-fix/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: bug-fix
+description: Fix bugs by first reproducing the issue, understanding the root cause, then making the minimal change to fix it. No refactoring or cleanup.
+---
+
+## Bug Fix Workflow
+
+1. Accept the bug report at face value. Don't question whether it's a real issue.
+2. Find the relevant code paths by understanding what the user was doing.
+3. Understand the root cause before writing any code.
+4. Make the smallest possible change to fix the bug.
+5. Do not refactor, rename, or clean up unrelated code.
+6. Do not add features or improvements.
+7. Verify the fix works by checking related code paths.
+8. If you're unsure about the fix, add a console.log or debug statement to confirm.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: deploy
+description: Deploy the React app to Netlify. Run npm run build, ensure netlify.toml is correct, and push to trigger CI. No manual deploy steps needed.
+---
+
+## Deploy
+
+- This is a Vite + React SPA deployed on Netlify.
+- `npm run build` outputs to `build/`.
+- `netlify.toml` is already configured for SPA builds.
+- Just push to the branch — Netlify auto-deploys.
+- Preview deploys are created automatically for PRs.
+- No manual Netlify CLI or web UI steps needed.

--- a/.claude/skills/feature-planning/SKILL.md
+++ b/.claude/skills/feature-planning/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: feature-planning
+description: Plan features by exploring the codebase first, understanding existing patterns, then proposing a minimal implementation plan before writing code.
+---
+
+## Feature Planning Workflow
+
+1. Explore the codebase to understand existing patterns and conventions.
+2. Check what libraries and tools are already in use — don't add new ones.
+3. Identify the minimal change needed. What's the smallest thing that works?
+4. Propose a plan before writing code.
+5. Keep scope narrow. One feature per branch.
+6. Prefer the existing pattern over a "better" one. Consistency > perfection.
+7. Don't extract abstractions too early. Wait until there are 3+ repetitions.
+8. No comments. Write self-documenting code.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: pr-review
+description: Review pull requests focusing on bugs, not style. Flag logic errors, crashes, and broken error handling. Ignore formatting, naming, and preferences.
+---
+
+## PR Review Rules
+
+- Only flag actual bugs. Not style, not preferences.
+- If you can't reproduce the bug, don't flag it.
+- Consider: will this cause a crash? If no, it's not a blocker.
+- Check for: logic errors, off-by-one, null/undefined access, missing error handling, race conditions, security issues.
+- Read the full file, not just the diff. Context matters.
+- Verify async operations have error handling. No silent failures.
+- localStorage access must always be wrapped in try-catch.
+- Every route and API call should have a loading state and an error state.

--- a/.claude/skills/refactoring/SKILL.md
+++ b/.claude/skills/refactoring/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: refactoring
+description: Refactor code to improve readability and consistency without changing behavior. Follow existing patterns, never add dependencies, delete more code than you add.
+---
+
+## Refactoring Rules
+
+- The best line of code is the one that doesn't exist. Delete more than you add.
+- Prefer flat over nested. Early returns over else chains.
+- If you need a comment to explain what the code does, refactor the code instead.
+- Use the same libraries and patterns already in the project.
+- Props drilling is fine up to 2 levels. After that, extract or use context.
+- Don't extract abstractions too early. Wait until 3+ repetitions.
+- Write code for humans first. Computers don't care.
+- Preserve existing behavior exactly. No hidden fixes or improvements.

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "skill": {
+      "*": "allow"
+    }
+  }
+}

--- a/.opencode/skills/bug-fix/SKILL.md
+++ b/.opencode/skills/bug-fix/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: bug-fix
+description: Fix bugs by first reproducing the issue, understanding the root cause, then making the minimal change to fix it. No refactoring or cleanup.
+---
+
+## Bug Fix Workflow
+
+1. Accept the bug report at face value. Don't question whether it's a real issue.
+2. Find the relevant code paths by understanding what the user was doing.
+3. Understand the root cause before writing any code.
+4. Make the smallest possible change to fix the bug.
+5. Do not refactor, rename, or clean up unrelated code.
+6. Do not add features or improvements.
+7. Verify the fix works by checking related code paths.
+8. If you're unsure about the fix, add a console.log or debug statement to confirm.

--- a/.opencode/skills/deploy/SKILL.md
+++ b/.opencode/skills/deploy/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: deploy
+description: Deploy the React app to Netlify. Run npm run build, ensure netlify.toml is correct, and push to trigger CI. No manual deploy steps needed.
+---
+
+## Deploy
+
+- This is a Vite + React SPA deployed on Netlify.
+- `npm run build` outputs to `build/`.
+- `netlify.toml` is already configured for SPA builds.
+- Just push to the branch — Netlify auto-deploys.
+- Preview deploys are created automatically for PRs.
+- No manual Netlify CLI or web UI steps needed.

--- a/.opencode/skills/feature-planning/SKILL.md
+++ b/.opencode/skills/feature-planning/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: feature-planning
+description: Plan features by exploring the codebase first, understanding existing patterns, then proposing a minimal implementation plan before writing code.
+---
+
+## Feature Planning Workflow
+
+1. Explore the codebase to understand existing patterns and conventions.
+2. Check what libraries and tools are already in use — don't add new ones.
+3. Identify the minimal change needed. What's the smallest thing that works?
+4. Propose a plan before writing code.
+5. Keep scope narrow. One feature per branch.
+6. Prefer the existing pattern over a "better" one. Consistency > perfection.
+7. Don't extract abstractions too early. Wait until there are 3+ repetitions.
+8. No comments. Write self-documenting code.

--- a/.opencode/skills/pr-review/SKILL.md
+++ b/.opencode/skills/pr-review/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: pr-review
+description: Review pull requests focusing on bugs, not style. Flag logic errors, crashes, and broken error handling. Ignore formatting, naming, and preferences.
+---
+
+## PR Review Rules
+
+- Only flag actual bugs. Not style, not preferences.
+- If you can't reproduce the bug, don't flag it.
+- Consider: will this cause a crash? If no, it's not a blocker.
+- Check for: logic errors, off-by-one, null/undefined access, missing error handling, race conditions, security issues.
+- Read the full file, not just the diff. Context matters.
+- Verify async operations have error handling. No silent failures.
+- localStorage access must always be wrapped in try-catch.
+- Every route and API call should have a loading state and an error state.

--- a/.opencode/skills/refactoring/SKILL.md
+++ b/.opencode/skills/refactoring/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: refactoring
+description: Refactor code to improve readability and consistency without changing behavior. Follow existing patterns, never add dependencies, delete more code than you add.
+---
+
+## Refactoring Rules
+
+- The best line of code is the one that doesn't exist. Delete more than you add.
+- Prefer flat over nested. Early returns over else chains.
+- If you need a comment to explain what the code does, refactor the code instead.
+- Use the same libraries and patterns already in the project.
+- Props drilling is fine up to 2 levels. After that, extract or use context.
+- Don't extract abstractions too early. Wait until 3+ repetitions.
+- Write code for humans first. Computers don't care.
+- Preserve existing behavior exactly. No hidden fixes or improvements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+## Core Principles
+
+- Ship fast. Perfect is the enemy of done.
+- Delete code, don't add it. The best line of code is the one that doesn't exist.
+- Prefer the existing pattern in the codebase over a "better" one. Consistency > perfection.
+- If it takes longer than 5 minutes to think about how to name something, you're overthinking it.
+
+## Code Rules
+
+- Write code for humans first. Computers don't care.
+- No comments unless the code genuinely cannot be made self-documenting.
+- If you need a comment to explain what the code does, refactor the code instead.
+- Use the same libraries and patterns already in the project. Don't introduce new dependencies.
+- Don't extract abstractions too early. Wait until there are 3+ repetitions.
+- Prefer flat over nested. Early returns over else chains.
+- Props drilling is fine up to 2 levels. After that, extract or use context.
+
+## Communication
+
+- Don't ask "should I..." — just do what makes sense. You have context.
+- Don't add summary or explanation of changes unless asked.
+- Don't mention linting, testing, or build output in PR descriptions or messages. It's noise.
+- When the user points out a mistake, fix it immediately. Don't explain why it happened.
+- No emojis. No fluff. Direct answers.
+
+## Error Handling
+
+- Every async operation needs error handling. No silent failures.
+- If a feature can't work without a backend, show a clear message. Don't silently fail.
+- localStorage access must always be wrapped in try-catch.
+
+## Git
+
+- Create a branch before making changes. Never commit directly to main.
+- Branch names: `phase-{number}-{slug}` for features, `fix-{slug}` for fixes.
+- Commit messages: short, imperative mood. No punctuation at end.
+- Always push the branch, never ask "should I push?"
+
+## When Reviewing PRs
+
+- Only flag actual bugs. Not style, not preferences.
+- If you can't reproduce the bug, don't flag it.
+- Consider: will this cause a crash? If no, it's not a blocker.


### PR DESCRIPTION
## Summary

Adds skill definitions for opencode agents and updates AGENTS.md with coding conventions and workflow rules.

## Changes

- Add skill definitions: bug-fix, deploy, feature-planning, pr-review, refactoring
- Configure skills in `.opencode/opencode.json`
- Update `AGENTS.md` with core principles, code rules, and git conventions